### PR TITLE
imporve wasm startup time.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "resolutions": {
     "typescript": "3.8.3",
-    "@webb-tools/mixer-client": "^0.0.6"
+    "@webb-tools/mixer-client": "^0.0.8"
   },
   "scripts": {
     "build": "yarn build:interfaces && polkadot-dev-build-ts",
@@ -22,7 +22,7 @@
     "test": "exit 0",
     "test:old": "cross-env NODE_OPTIONS=--experimental-vm-modules polkadot-dev-run-test --coverage",
     "check-deps": "./node_modules/@open-web3/util/scripts/check-deps.js yarn.lock @polkadot/ @open-web3/",
-    "update-metadata": "ts-node --project ./tsconfig.json packages/types/scripts/updateMetadata.ts",
+    "update-metadata": "ts-node-script -r tsconfig-paths/register packages/types/scripts/updateMetadata.ts",
     "example:sdk-mixer": "cd ./examples/sdk-mixer && yarn dev",
     "format": "prettier --write \"packages/**/*.{ts,js,jsx,tsx}\""
   },

--- a/packages/sdk-mixer/package.json
+++ b/packages/sdk-mixer/package.json
@@ -16,7 +16,7 @@
   "homepage": "https://github.com/webb-tools/webb.js",
   "dependencies": {
     "@polkadot/util": "^3.4.1",
-    "@webb-tools/mixer-client": "^0.0.6",
+    "@webb-tools/mixer-client": "^0.0.8",
     "@webb-tools/sdk-core": "^0.1.2-37",
     "@webb-tools/sdk-merkle": "^0.1.2-37",
     "lodash": "^4.17.20"

--- a/packages/sdk-mixer/src/wasm-thread.ts
+++ b/packages/sdk-mixer/src/wasm-thread.ts
@@ -7,11 +7,14 @@ type Asset = {
   id: number;
   tokenSymbol: TokenSymbol;
 };
-export type Events = 'init' | 'generateNote' | 'deposit' | 'withdraw';
+export type Events = 'init' | 'generateNote' | 'deposit' | 'withdraw' | 'preGenerateBulletproofGens';
 export type WasmMessage = Record<Events, unknown>;
 
 export interface WasmWorkerMessageTX extends WasmMessage {
   init: void;
+  preGenerateBulletproofGens: {
+    bulletproofGens: Uint8Array;
+  };
   generateNote: {
     note: string;
   };
@@ -32,7 +35,9 @@ export interface WasmWorkerMessageRX extends WasmMessage {
   generateNote: Asset;
   init: {
     mixerGroup: Array<[TokenSymbol, number, number]>;
+    bulletproofGens?: Uint8Array;
   };
+  preGenerateBulletproofGens: void;
   deposit: {
     note?: string;
     asset?: Asset;
@@ -42,6 +47,7 @@ export interface WasmWorkerMessageRX extends WasmMessage {
     leaves: Array<Uint8Array>;
     root: Uint8Array;
     note: string;
+    bulletproofGens?: Uint8Array;
   };
 }
 
@@ -65,11 +71,29 @@ export class WasmMixer {
     });
   }
 
-  init(mixerGroup: Array<[TokenSymbol, number, number]>): void {
+  preGenerateBulletproofGens(): void {
     import('@webb-tools/mixer-client')
       .then((wasm) => {
+        const opts = new wasm.PoseidonHasherOptions();
+        const bulletproofGens = opts.bp_gens;
+        this.emit('preGenerateBulletproofGens', { bulletproofGens }, false);
+      })
+      .catch((e) => {
+        this.logger.error(`Failed to initialized the poseidon hasher`, e);
+        this.emit('preGenerateBulletproofGens', e, true);
+      });
+  }
+
+  init(mixerGroup: Array<[TokenSymbol, number, number]>, bulletproofGens?: Uint8Array): void {
+    import('@webb-tools/mixer-client')
+      .then((wasm) => {
+        const opts = new wasm.PoseidonHasherOptions();
+        if (bulletproofGens && bulletproofGens.length !== 0) {
+          opts.bp_gens = bulletproofGens;
+        }
+        const hasher = new wasm.PoseidonHasher(opts);
         this.logger.debug('Mixer initialized with mixerGroup ', mixerGroup);
-        this.mixer = wasm.Mixer.new(mixerGroup);
+        this.mixer = new wasm.Mixer(mixerGroup, hasher);
         this.emit('init', undefined);
       })
       .catch((e) => {
@@ -125,7 +149,8 @@ export class WasmMixer {
     mixerGroup: Array<[TokenSymbol, number, number]>,
     note: string,
     root: Uint8Array,
-    leaves: Array<Uint8Array>
+    leaves: Array<Uint8Array>,
+    bulletproofGens?: Uint8Array
   ): void {
     if (!this.mixer) {
       this.emit('withdraw', 'Mixer is not initialized', true);
@@ -137,8 +162,13 @@ export class WasmMixer {
       import('@webb-tools/mixer-client')
         .then((wasm) => {
           this.logger.debug('Created a new Mixer for Withdrawer..');
-          const mixer = wasm.Mixer.new(mixerGroup);
-          mixer.add_leaves(mynote.tokenSymbol, mynote.id, leaves);
+          const opts = new wasm.PoseidonHasherOptions();
+          if (bulletproofGens && bulletproofGens.length !== 0) {
+            opts.bp_gens = bulletproofGens;
+          }
+          const hasher = new wasm.PoseidonHasher(opts);
+          const mixer = new wasm.Mixer(mixerGroup, hasher);
+          mixer.add_leaves(mynote.tokenSymbol, mynote.id, leaves, root);
           const savedNote = mixer.save_note(note);
           const leaf = savedNote.get('leaf') as Uint8Array;
           const zkProofMap = mixer.generate_proof(mynote.tokenSymbol, mynote.id, root, leaf) as ZKProofMap;
@@ -181,13 +211,22 @@ export class WasmMixer {
         this.generateNote(event[name]);
         break;
       case 'init':
-        this.init(event[name].mixerGroup);
+        this.init(event[name].mixerGroup, event[name].bulletproofGens);
         break;
       case 'deposit':
         this.deposit(event[name].note, event[name].asset);
         break;
       case 'withdraw':
-        this.withdraw(event[name].mixerGroup, event[name].note, event[name].root, event[name].leaves);
+        this.withdraw(
+          event[name].mixerGroup,
+          event[name].note,
+          event[name].root,
+          event[name].leaves,
+          event[name].bulletproofGens
+        );
+        break;
+      case 'preGenerateBulletproofGens':
+        this.preGenerateBulletproofGens();
         break;
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2571,10 +2571,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@webb-tools/mixer-client@npm:^0.0.6":
-  version: 0.0.6
-  resolution: "@webb-tools/mixer-client@npm:0.0.6"
-  checksum: b563e66d2cfe32831bb0d3806cbaf8f5f2ae851f111ef31b5bbbbaa68bb5cf9d7363a69a6167e388c8294ff6a450b299823c72f4597f376b42f310944ebf9ee6
+"@webb-tools/mixer-client@npm:^0.0.8":
+  version: 0.0.8
+  resolution: "@webb-tools/mixer-client@npm:0.0.8"
+  checksum: 20b420cd257982b8070b77e9a6023f064348ac6c2b87c3f023119fddaa7410bf822b57bc5f311d29cbbf9e927241aa0cbbd282f25136eeab86127969b30d5b72
   languageName: node
   linkType: hard
 
@@ -2610,7 +2610,7 @@ __metadata:
   dependencies:
     "@polkadot/util": ^3.4.1
     "@types/lodash": ^4.14.161
-    "@webb-tools/mixer-client": ^0.0.6
+    "@webb-tools/mixer-client": ^0.0.8
     "@webb-tools/sdk-core": ^0.1.2-37
     "@webb-tools/sdk-merkle": ^0.1.2-37
     lodash: ^4.17.20


### PR DESCRIPTION
An Example of using this new API:

```ts
// inside some hook (say useMixer)
...
// A place to store the cached bulletproof gens
const [bulletproofGens, setBulletproofGens] = useLocalStorage('bulletproof_gens');
// create a new web worker

const worker = new Worker();

let gens: Uint8Array;

// check if we already have a cached gens
if (bulletproofGens) {
	const encoder = new TextEncoder();
	gens = encoder.encode(bulletproofGens); // from string to Uint8Array
} else {
	// we need to regenerate it.
	const bpgens = await Mixer.preGenerateBulletproofGens(worker);
	const decoder = new TextDecoder();
	setBulletproofGens(decoder.decode(bpgens));
	gens = bpgens;
}

const mixerIds = []; // this fetched from the API.

// now we can start the mixer.
const mixer = await Mixer.init(worker, mixerIds, gens);


```

This should resolve the startup speed issue we have.

Related PRs: https://github.com/webb-tools/anon/pull/102