### PR TITLE
Enhanced event bus

### DIFF
--- a/packages/app-util/src/__test__/event-bus.class.spec.ts
+++ b/packages/app-util/src/__test__/event-bus.class.spec.ts
@@ -1,8 +1,15 @@
-import { EventBus } from '../shared/event-bus.class';
+import {EventBus} from '../shared/event-bus.class';
+
+class TestEvent extends EventBus<{ log: number }> {
+  readonly sendEvent: EventBus<{ log: number }>['emit'];
+
+  constructor() {
+    super();
+    this.sendEvent = this.emit;
+  }
+}
 
 describe('event emitting', () => {
-  class TestEvent extends EventBus<{ log: number }> {}
-
   const testEvent = new TestEvent();
   test('event should be  emitted', () => {
     let a = 0;
@@ -10,7 +17,7 @@ describe('event emitting', () => {
       a = a + 1;
     });
     expect(a).toEqual(0);
-    testEvent.emit('log', 5);
+    testEvent.sendEvent('log', 5);
     setTimeout(() => {
       expect(a).toEqual(1);
     }, 1);
@@ -23,7 +30,7 @@ describe('event emitting', () => {
     testEvent.on('log', (value) => {
       a = value;
     });
-    testEvent.emit('log', 5);
+    testEvent.sendEvent('log', 5);
     setTimeout(() => {
       expect(a).toEqual(5);
     }, 1);
@@ -31,21 +38,41 @@ describe('event emitting', () => {
 });
 
 describe('Subscriptions', () => {
-  class TestEvent extends EventBus<{ log: number }> {}
-
-  const testEvent = new TestEvent();
   test('should unsubscribe', () => {
+    const testEvent = new TestEvent();
     let a = 0;
     const unsubscribe = testEvent.on('log', () => {
       a = a + 1;
     });
     expect(a).toEqual(0);
-    testEvent.emit('log', 5);
+    testEvent.sendEvent('log', 5);
     if (unsubscribe) {
       unsubscribe();
     }
     setTimeout(() => {
       expect(a).toEqual(0);
     }, 1);
+  });
+  test('Once will trigger only one time', () => {
+    const testEvent = new TestEvent();
+    let a = 0;
+    testEvent.once('log', (log) => {
+      a = log;
+    });
+    testEvent.sendEvent('log', 1);
+    testEvent.sendEvent('log', 2);
+    expect(a).toEqual(1);
+  });
+
+  test('Unsubscribe all', () => {
+    const testEvent = new TestEvent();
+    let a = 0;
+    testEvent.on('log', (log) => {
+      a = log;
+    });
+    testEvent.unsubscribeAll();
+    testEvent.sendEvent('log', 1);
+    testEvent.sendEvent('log', 2);
+    expect(a).toEqual(0);
   });
 });

--- a/packages/app-util/src/shared/event-bus.class.ts
+++ b/packages/app-util/src/shared/event-bus.class.ts
@@ -4,24 +4,55 @@ export type Subscription<T extends Event = Event> = {
 };
 
 export abstract class EventBus<T extends Event> {
+  /**
+   * Optionally expose the `emit` functionality outside the implementor
+   * */
+  sendEvent: undefined | (<E extends keyof T>(event: E, data: T[E]) => void) = undefined;
   protected subscriptions: Subscription<T> = {} as Subscription<T>;
 
-  on = <E extends keyof T>(event: E, cb: (val: T[E]) => void): (() => void) | void => {
+  /**
+   * @description register an event and pass a callback
+   * @return Void|Function  , Void if the handler is already registered or Function if the handler is registered
+   * */
+  on<E extends keyof T>(event: E, cb: (val: T[E]) => void): (() => void) | void {
     const listeners = this.subscriptions[event];
     if (listeners && listeners.indexOf(cb) > -1) {
       return;
     }
     this.subscriptions[event] = [...(this.subscriptions[event] || []), cb];
     return () => this.off(event, cb);
-  };
+  }
 
-  emit = <E extends keyof T>(event: E, data: T[E]): void | Promise<void> => {
+  /**
+   * emit an event
+   * */
+  protected emit<E extends keyof T>(event: E, data: T[E]): void {
     this.subscriptions[event]?.forEach((cb) => cb(data));
-  };
+  }
 
-  off = <E extends keyof T>(event: E, cb: (val: T[E]) => void): void | Promise<void> => {
+  /**
+   *  Unregister the listener for an event
+   *  the reference of the callback function
+   * */
+  protected off<E extends keyof T>(event: E, cb: (val: T[E]) => void): void {
     const listeners = this.subscriptions[event];
 
     this.subscriptions[event] = listeners ? [] : this.subscriptions[event].filter((c) => c !== cb);
-  };
+  }
+
+  once<E extends keyof T>(event: E, cb: (val: T[E]) => void): () => void {
+    const hookedCb = (val: T[E]) => {
+      cb(val);
+      this.off(event, hookedCb);
+    };
+    this.subscriptions[event] = [...(this.subscriptions[event] || []), hookedCb];
+    return () => this.off(event, hookedCb);
+  }
+
+  unsubscribeAll() {
+    this.subscriptions = {} as Subscription<T>;
+  }
+  unsubscribeAllForEvent<E extends keyof T>(event: E) {
+    this.subscriptions[event] = [];
+  }
 }

--- a/packages/app-util/src/shared/event-bus.class.ts
+++ b/packages/app-util/src/shared/event-bus.class.ts
@@ -14,12 +14,11 @@ export abstract class EventBus<T extends Event> {
    * @description register an event and pass a callback
    * @return Void|Function  , Void if the handler is already registered or Function if the handler is registered
    * */
-  on<E extends keyof T>(event: E, cb: (val: T[E]) => void): (() => void) | void {
+  on<E extends keyof T>(event: E, cb: (val: T[E]) => void): () => void {
     const listeners = this.subscriptions[event];
-    if (listeners && listeners.indexOf(cb) > -1) {
-      return;
+    if (listeners && listeners.indexOf(cb) === -1) {
+      this.subscriptions[event] = [...(this.subscriptions[event] || []), cb];
     }
-    this.subscriptions[event] = [...(this.subscriptions[event] || []), cb];
     return () => this.off(event, cb);
   }
 
@@ -52,6 +51,7 @@ export abstract class EventBus<T extends Event> {
   unsubscribeAll() {
     this.subscriptions = {} as Subscription<T>;
   }
+
   unsubscribeAllForEvent<E extends keyof T>(event: E) {
     this.subscriptions[event] = [];
   }


### PR DESCRIPTION
Enhancements
- Add once for optional cleanup
- Add unsubscribe all and unsubscribe for a certain event
- Change the `emit` function to be protected and added optional`SendEvent` for optional exposure of `emit` function
- `on` will always return off the handler