### PR TITLE
Note Generator cleanup

### DIFF
--- a/packages/wasm-utils/Cargo.lock
+++ b/packages/wasm-utils/Cargo.lock
@@ -287,7 +287,9 @@ dependencies = [
 
 [[package]]
 name = "arkworks-gadgets"
-version = "0.3.6"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5362297eb49be265d0f87d63ef983a168af65252a59d21be325c3a7e0291b544"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",

--- a/packages/wasm-utils/Cargo.lock
+++ b/packages/wasm-utils/Cargo.lock
@@ -287,9 +287,7 @@ dependencies = [
 
 [[package]]
 name = "arkworks-gadgets"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c86a7f65a36d0d36d948e56e075bd01e0bb918ff56b8ca14719a652cf8e7006"
+version = "0.3.6"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",

--- a/packages/wasm-utils/Cargo.toml
+++ b/packages/wasm-utils/Cargo.toml
@@ -21,10 +21,10 @@ lto = true
 
 [dependencies]
 ark-ff = { version = "^0.3.0", default-features = true }
-ark-crypto-primitives = { version = "^0.3.0", default-features = true, features = [ "r1cs" ] }
-ark-ed-on-bn254 = { version = "^0.3.0", default-features = true, features = [ "r1cs" ] }
+ark-crypto-primitives = { version = "^0.3.0", default-features = true, features = ["r1cs"] }
+ark-ed-on-bn254 = { version = "^0.3.0", default-features = true, features = ["r1cs"] }
 pedersen-hash = { version = "0.1.0", git = "https://github.com/webb-tools/webb-rs.git", package = "pedersen-hash" }
-arkworks-gadgets = {path = '../../../arkworks-gadgets'}
+arkworks-gadgets = { version = "0.3.7" }
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 js-sys = "0.3"
 rand = { version = "0.7", features = ["wasm-bindgen"] }

--- a/packages/wasm-utils/Cargo.toml
+++ b/packages/wasm-utils/Cargo.toml
@@ -24,7 +24,7 @@ ark-ff = { version = "^0.3.0", default-features = true }
 ark-crypto-primitives = { version = "^0.3.0", default-features = true, features = [ "r1cs" ] }
 ark-ed-on-bn254 = { version = "^0.3.0", default-features = true, features = [ "r1cs" ] }
 pedersen-hash = { version = "0.1.0", git = "https://github.com/webb-tools/webb-rs.git", package = "pedersen-hash" }
-arkworks-gadgets = "0.3.5"
+arkworks-gadgets = {path = '../../../arkworks-gadgets'}
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 js-sys = "0.3"
 rand = { version = "0.7", features = ["wasm-bindgen"] }

--- a/packages/wasm-utils/src/arkworks_poseidon_bls12_381.rs
+++ b/packages/wasm-utils/src/arkworks_poseidon_bls12_381.rs
@@ -11,6 +11,12 @@ use arkworks_gadgets::poseidon::{PoseidonParameters, Rounds, CRH};
 use arkworks_gadgets::prelude::ark_bls12_381::{Bls12_381, Fr};
 use arkworks_gadgets::prelude::ark_std::rand::SeedableRng;
 use arkworks_gadgets::prelude::*;
+use arkworks_gadgets::setup::common::{
+	setup_params_x17_3, setup_params_x17_5, setup_params_x3_3, setup_params_x3_5, setup_params_x5_5, Curve,
+	PoseidonCRH_x17_3, PoseidonCRH_x17_5, PoseidonCRH_x3_3, PoseidonCRH_x3_5, PoseidonCRH_x5_3, PoseidonCRH_x5_5,
+	PoseidonRounds_x17_3, PoseidonRounds_x17_5, PoseidonRounds_x3_3, PoseidonRounds_x3_5, PoseidonRounds_x5_3,
+	PoseidonRounds_x5_5,
+};
 use arkworks_gadgets::utils::{
 	get_mds_poseidon_bls381_x17_3, get_mds_poseidon_bls381_x3_3, get_mds_poseidon_bls381_x3_5,
 	get_mds_poseidon_bls381_x5_3, get_mds_poseidon_bls381_x5_5, get_mds_poseidon_bn254_x17_5,
@@ -27,91 +33,12 @@ pub struct ArkworksPoseidonBls12_381NoteGenerator {
 	exponentiation: usize,
 	width: usize,
 }
-/// Poseidon width 3
-
-/// 5 3
-#[derive(Default, Clone)]
-struct PoseidonRounds5_3;
-impl Rounds for PoseidonRounds5_3 {
-	const FULL_ROUNDS: usize = 8;
-	const PARTIAL_ROUNDS: usize = 57;
-	const SBOX: PoseidonSbox = PoseidonSbox::Exponentiation(5);
-	const WIDTH: usize = 3;
-}
-type PoseidonCRH5_3 = CRH<Fr, PoseidonRounds5_3>;
-
-type Leaf5_3 = MixerLeaf<Fr, PoseidonCRH5_3>;
-
-/// 3 3
-
-#[derive(Default, Clone)]
-struct PoseidonRounds3_3;
-
-impl Rounds for PoseidonRounds3_3 {
-	const FULL_ROUNDS: usize = 8;
-	const PARTIAL_ROUNDS: usize = 84;
-	const SBOX: PoseidonSbox = PoseidonSbox::Exponentiation(3);
-	const WIDTH: usize = 3;
-}
-type PoseidonCRH3_3 = CRH<Fr, PoseidonRounds3_3>;
-
-type Leaf3_3 = MixerLeaf<Fr, PoseidonCRH3_3>;
-
-/// Poseidon width 5
-
-// 5 5
-#[derive(Default, Clone)]
-struct PoseidonRounds5_5;
-
-impl Rounds for PoseidonRounds5_5 {
-	const FULL_ROUNDS: usize = 8;
-	const PARTIAL_ROUNDS: usize = 60;
-	const SBOX: PoseidonSbox = PoseidonSbox::Exponentiation(5);
-	const WIDTH: usize = 5;
-}
-type PoseidonCRH5_5 = CRH<Fr, PoseidonRounds5_5>;
-
-type Leaf5_5 = MixerLeaf<Fr, PoseidonCRH5_5>;
-
-// 3 5
-#[derive(Default, Clone)]
-struct PoseidonRounds3_5;
-
-impl Rounds for PoseidonRounds3_5 {
-	const FULL_ROUNDS: usize = 8;
-	const PARTIAL_ROUNDS: usize = 85;
-	const SBOX: PoseidonSbox = PoseidonSbox::Exponentiation(3);
-	const WIDTH: usize = 5;
-}
-type PoseidonCRH3_5 = CRH<Fr, PoseidonRounds3_5>;
-
-type Leaf3_5 = MixerLeaf<Fr, PoseidonCRH3_5>;
-// 17 3
-#[derive(Default, Clone)]
-struct PoseidonRounds17_3;
-
-impl Rounds for PoseidonRounds17_3 {
-	const FULL_ROUNDS: usize = 8;
-	const PARTIAL_ROUNDS: usize = 33;
-	const SBOX: PoseidonSbox = PoseidonSbox::Exponentiation(17);
-	const WIDTH: usize = 5;
-}
-type PoseidonCRH17_3 = CRH<Fr, PoseidonRounds17_3>;
-
-type Leaf17_3 = MixerLeaf<Fr, PoseidonCRH17_3>;
-// 17 5
-#[derive(Default, Clone)]
-struct PoseidonRounds17_5;
-
-impl Rounds for PoseidonRounds17_5 {
-	const FULL_ROUNDS: usize = 8;
-	const PARTIAL_ROUNDS: usize = 35;
-	const SBOX: PoseidonSbox = PoseidonSbox::Exponentiation(17);
-	const WIDTH: usize = 5;
-}
-type PoseidonCRH17_5 = CRH<Fr, PoseidonRounds17_5>;
-
-type Leaf17_5 = MixerLeaf<Fr, PoseidonCRH17_5>;
+type Leaf5_3 = MixerLeaf<Fr, PoseidonCRH_x5_3<Fr>>;
+type Leaf5_5 = MixerLeaf<Fr, PoseidonCRH_x5_5<Fr>>;
+type Leaf3_3 = MixerLeaf<Fr, PoseidonCRH_x3_3<Fr>>;
+type Leaf3_5 = MixerLeaf<Fr, PoseidonCRH_x3_5<Fr>>;
+type Leaf17_5 = MixerLeaf<Fr, PoseidonCRH_x17_5<Fr>>;
+type Leaf17_3 = MixerLeaf<Fr, PoseidonCRH_x17_3<Fr>>;
 
 const SEED: &[u8; 32] = b"WebbToolsPedersenHasherSeedBytes";
 impl NoteGenerator for ArkworksPoseidonBls12_381NoteGenerator {
@@ -121,13 +48,9 @@ impl NoteGenerator for ArkworksPoseidonBls12_381NoteGenerator {
 		let secrets = match (self.exponentiation, self.width) {
 			(5, 3) => Leaf5_3::generate_secrets(&mut r).map_err(|_| OpStatusCode::SecretGenFailed)?,
 			(5, 5) => Leaf5_5::generate_secrets(&mut r).map_err(|_| OpStatusCode::SecretGenFailed)?,
-
 			(3, 3) => Leaf3_3::generate_secrets(&mut r).map_err(|_| OpStatusCode::SecretGenFailed)?,
-
 			(3, 5) => Leaf3_5::generate_secrets(&mut r).map_err(|_| OpStatusCode::SecretGenFailed)?,
-
 			(17, 3) => Leaf17_3::generate_secrets(&mut r).map_err(|_| OpStatusCode::SecretGenFailed)?,
-
 			(17, 5) => Leaf17_5::generate_secrets(&mut r).map_err(|_| OpStatusCode::SecretGenFailed)?,
 			_ => {
 				unimplemented!()
@@ -149,16 +72,16 @@ impl LeafHasher for ArkworksPoseidonBls12_381NoteGenerator {
 			return Err(OpStatusCode::InvalidNoteLength);
 		}
 		let leaf_res = match (self.exponentiation, self.width) {
-			(5, 3) => PoseidonCRH5_3::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?,
-			(5, 5) => PoseidonCRH5_5::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?,
-
-			(3, 3) => PoseidonCRH3_3::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?,
-
-			(3, 5) => PoseidonCRH3_5::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?,
-
-			(17, 3) => PoseidonCRH17_3::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?,
-
-			(17, 5) => PoseidonCRH17_5::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?,
+			(5, 3) => PoseidonCRH_x5_3::<Fr>::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?,
+			(5, 5) => PoseidonCRH_x5_5::<Fr>::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?,
+			(3, 3) => PoseidonCRH_x3_3::<Fr>::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?,
+			(3, 5) => PoseidonCRH_x3_5::<Fr>::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?,
+			(17, 3) => {
+				PoseidonCRH_x17_3::<Fr>::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?
+			}
+			(17, 5) => {
+				PoseidonCRH_x17_3::<Fr>::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?
+			}
 			_ => {
 				unimplemented!()
 			}
@@ -171,36 +94,12 @@ impl LeafHasher for ArkworksPoseidonBls12_381NoteGenerator {
 impl ArkworksPoseidonBls12_381NoteGenerator {
 	fn get_params(&self) -> PoseidonParameters<Fr> {
 		match (self.exponentiation, self.width) {
-			(5, 3) => {
-				let rounds = get_rounds_poseidon_bls381_x5_3::<Fr>();
-				let mds = get_mds_poseidon_bls381_x5_3::<Fr>();
-				PoseidonParameters::<Fr>::new(rounds, mds)
-			}
-			(5, 5) => {
-				let rounds = get_rounds_poseidon_bls381_x5_5::<Fr>();
-				let mds = get_mds_poseidon_bls381_x5_5::<Fr>();
-				PoseidonParameters::<Fr>::new(rounds, mds)
-			}
-			(3, 3) => {
-				let rounds = get_rounds_poseidon_bls381_x3_3::<Fr>();
-				let mds = get_mds_poseidon_bls381_x3_3::<Fr>();
-				PoseidonParameters::<Fr>::new(rounds, mds)
-			}
-			(3, 5) => {
-				let rounds = get_rounds_poseidon_bls381_x3_5::<Fr>();
-				let mds = get_mds_poseidon_bls381_x3_5::<Fr>();
-				PoseidonParameters::<Fr>::new(rounds, mds)
-			}
-			(17, 3) => {
-				let rounds = get_rounds_poseidon_bls381_x17_3::<Fr>();
-				let mds = get_mds_poseidon_bls381_x17_3::<Fr>();
-				PoseidonParameters::<Fr>::new(rounds, mds)
-			}
-			(17, 5) => {
-				let rounds = get_rounds_poseidon_bls381_x17_5::<Fr>();
-				let mds = get_mds_poseidon_bn254_x17_5::<Fr>();
-				PoseidonParameters::<Fr>::new(rounds, mds)
-			}
+			(5, 3) => setup_params_x3_3::<Fr>(Curve::Bls381),
+			(5, 5) => setup_params_x5_5::<Fr>(Curve::Bls381),
+			(3, 3) => setup_params_x3_3::<Fr>(Curve::Bls381),
+			(3, 5) => setup_params_x3_5::<Fr>(Curve::Bls381),
+			(17, 3) => setup_params_x17_3::<Fr>(Curve::Bls381),
+			(17, 5) => setup_params_x17_5::<Fr>(Curve::Bls381),
 			_ => {
 				unreachable!()
 			}
@@ -231,7 +130,7 @@ mod test {
 	fn test_arch() {
 		#[test]
 		fn arkworks_poseidon_bls12_381_note_generator_5x_3() {
-			let note_generator = ArkworksPoseidonBls12_381NoteGenerator::set_up(PoseidonRounds5_3);
+			let note_generator = ArkworksPoseidonBls12_381NoteGenerator::set_up(PoseidonRounds_x5_3);
 			let secrets = note_generator.generate_secrets(&mut OsRng::default()).unwrap();
 			let leaf = note_generator.hash(&secrets, note_generator.get_params()).unwrap();
 			let note = note_generator
@@ -241,7 +140,7 @@ mod test {
 		}
 		#[test]
 		fn arkworks_poseidon_bls12_381_note_generator_5x_5() {
-			let note_generator = ArkworksPoseidonBls12_381NoteGenerator::set_up(PoseidonRounds5_5);
+			let note_generator = ArkworksPoseidonBls12_381NoteGenerator::set_up(PoseidonRounds_x5_5);
 			let secrets = note_generator.generate_secrets(&mut OsRng::default()).unwrap();
 			let leaf = note_generator.hash(&secrets, note_generator.get_params()).unwrap();
 			let note = note_generator
@@ -251,7 +150,7 @@ mod test {
 		}
 		#[test]
 		fn arkworks_poseidon_bls12_381_note_generator_3x_3() {
-			let note_generator = ArkworksPoseidonBls12_381NoteGenerator::set_up(PoseidonRounds3_3);
+			let note_generator = ArkworksPoseidonBls12_381NoteGenerator::set_up(PoseidonRounds_x3_3);
 			let secrets = note_generator.generate_secrets(&mut OsRng::default()).unwrap();
 			let leaf = note_generator.hash(&secrets, note_generator.get_params()).unwrap();
 			let note = note_generator
@@ -261,7 +160,7 @@ mod test {
 		}
 		#[test]
 		fn arkworks_poseidon_bls12_381_note_generator_3x_5() {
-			let note_generator = ArkworksPoseidonBls12_381NoteGenerator::set_up(PoseidonRounds3_5);
+			let note_generator = ArkworksPoseidonBls12_381NoteGenerator::set_up(PoseidonRounds_x3_5);
 			let secrets = note_generator.generate_secrets(&mut OsRng::default()).unwrap();
 			let leaf = note_generator.hash(&secrets, note_generator.get_params()).unwrap();
 			let note = note_generator
@@ -271,7 +170,7 @@ mod test {
 		}
 		#[test]
 		fn arkworks_poseidon_bls12_381_note_generator_17x_3() {
-			let note_generator = ArkworksPoseidonBls12_381NoteGenerator::set_up(PoseidonRounds17_3);
+			let note_generator = ArkworksPoseidonBls12_381NoteGenerator::set_up(PoseidonRounds_x17_3);
 			let secrets = note_generator.generate_secrets(&mut OsRng::default()).unwrap();
 			let leaf = note_generator.hash(&secrets, note_generator.get_params()).unwrap();
 			let note = note_generator
@@ -282,7 +181,7 @@ mod test {
 
 		#[test]
 		fn arkworks_poseidon_bls12_381_note_generator_17x_5() {
-			let note_generator = ArkworksPoseidonBls12_381NoteGenerator::set_up(PoseidonRounds17_5);
+			let note_generator = ArkworksPoseidonBls12_381NoteGenerator::set_up(PoseidonRounds_x17_5);
 			let secrets = note_generator.generate_secrets(&mut OsRng::default()).unwrap();
 			let leaf = note_generator.hash(&secrets, note_generator.get_params()).unwrap();
 			let note = note_generator

--- a/packages/wasm-utils/src/arkworks_poseidon_bls12_381.rs
+++ b/packages/wasm-utils/src/arkworks_poseidon_bls12_381.rs
@@ -26,7 +26,6 @@ type Leaf3_5 = MixerLeaf<Fr, PoseidonCRH_x3_5<Fr>>;
 type Leaf17_5 = MixerLeaf<Fr, PoseidonCRH_x17_5<Fr>>;
 type Leaf17_3 = MixerLeaf<Fr, PoseidonCRH_x17_3<Fr>>;
 
-const SEED: &[u8; 32] = b"WebbToolsPedersenHasherSeedBytes";
 impl NoteGenerator for ArkworksPoseidonBls12_381NoteGenerator {
 	type Rng = rand::rngs::StdRng;
 
@@ -109,6 +108,7 @@ impl ArkworksPoseidonBls12_381NoteGenerator {
 #[cfg(test)]
 mod test {
 	use crate::note::NoteBuilder;
+	const SEED: &[u8; 32] = b"WebbToolsPedersenHasherSeedBytes";
 
 	use super::*;
 	use arkworks_gadgets::ark_std::rand;

--- a/packages/wasm-utils/src/arkworks_poseidon_bls12_381.rs
+++ b/packages/wasm-utils/src/arkworks_poseidon_bls12_381.rs
@@ -1,30 +1,17 @@
-use std::convert::TryInto;
-
-use ark_crypto_primitives::crh::injective_map::{PedersenCRHCompressor, TECompressor};
 use ark_crypto_primitives::CRH as CRHTrait;
 use ark_ff::fields::PrimeField;
-use ark_ff::{to_bytes, BigInteger, ToBytes};
+use ark_ff::{to_bytes, BigInteger};
 use arkworks_gadgets::ark_std::rand;
-use arkworks_gadgets::leaf::mixer::{MixerLeaf, Private};
+use arkworks_gadgets::leaf::mixer::MixerLeaf;
 use arkworks_gadgets::leaf::LeafCreation;
 use arkworks_gadgets::poseidon::sbox::PoseidonSbox;
-use arkworks_gadgets::poseidon::{PoseidonParameters, Rounds, CRH};
-use arkworks_gadgets::prelude::ark_bls12_381::{Bls12_381, Fr};
-use arkworks_gadgets::prelude::ark_std::rand::SeedableRng;
+use arkworks_gadgets::poseidon::{PoseidonParameters, Rounds};
+use arkworks_gadgets::prelude::ark_bls12_381::Fr;
 use arkworks_gadgets::prelude::*;
 use arkworks_gadgets::setup::common::{
 	setup_params_x17_3, setup_params_x17_5, setup_params_x3_3, setup_params_x3_5, setup_params_x5_5, Curve,
 	PoseidonCRH_x17_3, PoseidonCRH_x17_5, PoseidonCRH_x3_3, PoseidonCRH_x3_5, PoseidonCRH_x5_3, PoseidonCRH_x5_5,
-	PoseidonRounds_x17_3, PoseidonRounds_x17_5, PoseidonRounds_x3_3, PoseidonRounds_x3_5, PoseidonRounds_x5_3,
-	PoseidonRounds_x5_5,
 };
-use arkworks_gadgets::utils::{
-	get_mds_poseidon_bls381_x17_3, get_mds_poseidon_bls381_x3_3, get_mds_poseidon_bls381_x3_5,
-	get_mds_poseidon_bls381_x5_3, get_mds_poseidon_bls381_x5_5, get_mds_poseidon_bn254_x17_5,
-	get_rounds_poseidon_bls381_x17_3, get_rounds_poseidon_bls381_x17_5, get_rounds_poseidon_bls381_x3_3,
-	get_rounds_poseidon_bls381_x3_5, get_rounds_poseidon_bls381_x5_3, get_rounds_poseidon_bls381_x5_5,
-};
-use pedersen_hash::PedersenWindow;
 
 use crate::note::{LeafHasher, NoteGenerator, OpStatusCode};
 
@@ -125,6 +112,11 @@ mod test {
 
 	use super::*;
 	use arkworks_gadgets::ark_std::rand;
+	use arkworks_gadgets::ark_std::rand::SeedableRng;
+	use arkworks_gadgets::setup::common::{
+		PoseidonRounds_x17_3, PoseidonRounds_x17_5, PoseidonRounds_x3_3, PoseidonRounds_x3_5, PoseidonRounds_x5_3,
+		PoseidonRounds_x5_5,
+	};
 
 	#[test]
 	fn arkworks_poseidon_bls12_381_note_generator_5x_3() {

--- a/packages/wasm-utils/src/arkworks_poseidon_bn254.rs
+++ b/packages/wasm-utils/src/arkworks_poseidon_bn254.rs
@@ -26,7 +26,6 @@ type Leaf3_5 = MixerLeaf<Fr, PoseidonCRH_x3_5<Fr>>;
 type Leaf17_5 = MixerLeaf<Fr, PoseidonCRH_x17_5<Fr>>;
 type Leaf17_3 = MixerLeaf<Fr, PoseidonCRH_x17_3<Fr>>;
 
-const SEED: &[u8; 32] = b"WebbToolsPedersenHasherSeedBytes";
 impl NoteGenerator for ArkworksPoseidonBn254NoteGenerator {
 	type Rng = rand::rngs::StdRng;
 
@@ -110,6 +109,7 @@ impl ArkworksPoseidonBn254NoteGenerator {
 #[cfg(test)]
 mod test {
 	use arkworks_gadgets::ark_std::rand;
+	const SEED: &[u8; 32] = b"WebbToolsPedersenHasherSeedBytes";
 
 	use crate::note::NoteBuilder;
 

--- a/packages/wasm-utils/src/arkworks_poseidon_bn254.rs
+++ b/packages/wasm-utils/src/arkworks_poseidon_bn254.rs
@@ -7,7 +7,6 @@ use arkworks_gadgets::leaf::LeafCreation;
 use arkworks_gadgets::poseidon::sbox::PoseidonSbox;
 use arkworks_gadgets::poseidon::{PoseidonParameters, Rounds};
 use arkworks_gadgets::prelude::ark_bn254::Fr;
-use arkworks_gadgets::prelude::ark_std::rand::SeedableRng;
 use arkworks_gadgets::prelude::*;
 use arkworks_gadgets::setup::common::{
 	setup_params_x17_3, setup_params_x17_5, setup_params_x3_3, setup_params_x3_5, setup_params_x5_5, Curve,

--- a/packages/wasm-utils/src/arkworks_poseidon_bn254.rs
+++ b/packages/wasm-utils/src/arkworks_poseidon_bn254.rs
@@ -1,5 +1,6 @@
 use std::convert::TryInto;
 
+use crate::note::{LeafHasher, NoteGenerator, OpStatusCode};
 use ark_crypto_primitives::crh::injective_map::{PedersenCRHCompressor, TECompressor};
 use ark_crypto_primitives::CRH as CRHTrait;
 use ark_ff::fields::PrimeField;
@@ -11,6 +12,12 @@ use arkworks_gadgets::poseidon::{PoseidonParameters, Rounds, CRH};
 use arkworks_gadgets::prelude::ark_bn254::{Bn254, Fr};
 use arkworks_gadgets::prelude::ark_std::rand::SeedableRng;
 use arkworks_gadgets::prelude::*;
+use arkworks_gadgets::setup::common::{
+	setup_params_x17_3, setup_params_x17_5, setup_params_x3_3, setup_params_x3_5, setup_params_x5_5, Curve,
+	PoseidonCRH_x17_3, PoseidonCRH_x17_5, PoseidonCRH_x3_3, PoseidonCRH_x3_5, PoseidonCRH_x5_3, PoseidonCRH_x5_5,
+	PoseidonRounds_x17_3, PoseidonRounds_x17_5, PoseidonRounds_x3_3, PoseidonRounds_x3_5, PoseidonRounds_x5_3,
+	PoseidonRounds_x5_5,
+};
 use arkworks_gadgets::utils::{
 	get_mds_poseidon_bn254_x17_3, get_mds_poseidon_bn254_x17_5, get_mds_poseidon_bn254_x3_3,
 	get_mds_poseidon_bn254_x3_5, get_mds_poseidon_bn254_x5_3, get_mds_poseidon_bn254_x5_5,
@@ -22,99 +29,16 @@ use pedersen_hash::PedersenWindow;
 use rand::rngs::OsRng;
 use rand::Rng;
 
-use crate::note::{LeafHasher, NoteGenerator, OpStatusCode};
-
 pub struct ArkworksPoseidonBn254NoteGenerator {
 	exponentiation: usize,
 	width: usize,
 }
-/// Poseidon width 3
-
-/// 5 3
-#[derive(Default, Clone)]
-struct PoseidonRounds5_3;
-impl Rounds for PoseidonRounds5_3 {
-	const FULL_ROUNDS: usize = 8;
-	const PARTIAL_ROUNDS: usize = 57;
-	const SBOX: PoseidonSbox = PoseidonSbox::Exponentiation(5);
-	const WIDTH: usize = 3;
-}
-type PoseidonCRH5_3 = CRH<Fr, PoseidonRounds5_3>;
-
-type Leaf5_3 = MixerLeaf<Fr, PoseidonCRH5_3>;
-
-/// 3 3
-
-#[derive(Default, Clone)]
-struct PoseidonRounds3_3;
-
-impl Rounds for PoseidonRounds3_3 {
-	const FULL_ROUNDS: usize = 8;
-	const PARTIAL_ROUNDS: usize = 84;
-	const SBOX: PoseidonSbox = PoseidonSbox::Exponentiation(3);
-	const WIDTH: usize = 3;
-}
-type PoseidonCRH3_3 = CRH<Fr, PoseidonRounds3_3>;
-
-type Leaf3_3 = MixerLeaf<Fr, PoseidonCRH3_3>;
-
-/// Poseidon width 5
-
-// 5 5
-#[derive(Default, Clone)]
-struct PoseidonRounds5_5;
-
-impl Rounds for PoseidonRounds5_5 {
-	const FULL_ROUNDS: usize = 8;
-	const PARTIAL_ROUNDS: usize = 60;
-	const SBOX: PoseidonSbox = PoseidonSbox::Exponentiation(5);
-	const WIDTH: usize = 5;
-}
-type PoseidonCRH5_5 = CRH<Fr, PoseidonRounds5_5>;
-
-type Leaf5_5 = MixerLeaf<Fr, PoseidonCRH5_5>;
-
-// 3 5
-#[derive(Default, Clone)]
-struct PoseidonRounds3_5;
-
-impl Rounds for PoseidonRounds3_5 {
-	const FULL_ROUNDS: usize = 8;
-	const PARTIAL_ROUNDS: usize = 85;
-	const SBOX: PoseidonSbox = PoseidonSbox::Exponentiation(3);
-	const WIDTH: usize = 5;
-}
-type PoseidonCRH3_5 = CRH<Fr, PoseidonRounds3_5>;
-
-type Leaf3_5 = MixerLeaf<Fr, PoseidonCRH3_5>;
-
-// 17 3
-#[derive(Default, Clone)]
-struct PoseidonRounds17_3;
-
-impl Rounds for PoseidonRounds17_3 {
-	const FULL_ROUNDS: usize = 8;
-	const PARTIAL_ROUNDS: usize = 33;
-	const SBOX: PoseidonSbox = PoseidonSbox::Exponentiation(17);
-	const WIDTH: usize = 5;
-}
-type PoseidonCRH17_3 = CRH<Fr, PoseidonRounds17_3>;
-
-type Leaf17_3 = MixerLeaf<Fr, PoseidonCRH17_3>;
-
-// 17 3
-#[derive(Default, Clone)]
-struct PoseidonRounds17_5;
-
-impl Rounds for PoseidonRounds17_5 {
-	const FULL_ROUNDS: usize = 8;
-	const PARTIAL_ROUNDS: usize = 35;
-	const SBOX: PoseidonSbox = PoseidonSbox::Exponentiation(17);
-	const WIDTH: usize = 5;
-}
-type PoseidonCRH17_5 = CRH<Fr, PoseidonRounds17_5>;
-
-type Leaf17_5 = MixerLeaf<Fr, PoseidonCRH17_5>;
+type Leaf5_3 = MixerLeaf<Fr, PoseidonCRH_x5_3<Fr>>;
+type Leaf5_5 = MixerLeaf<Fr, PoseidonCRH_x5_5<Fr>>;
+type Leaf3_3 = MixerLeaf<Fr, PoseidonCRH_x3_3<Fr>>;
+type Leaf3_5 = MixerLeaf<Fr, PoseidonCRH_x3_5<Fr>>;
+type Leaf17_5 = MixerLeaf<Fr, PoseidonCRH_x17_5<Fr>>;
+type Leaf17_3 = MixerLeaf<Fr, PoseidonCRH_x17_3<Fr>>;
 
 const SEED: &[u8; 32] = b"WebbToolsPedersenHasherSeedBytes";
 impl NoteGenerator for ArkworksPoseidonBn254NoteGenerator {
@@ -125,13 +49,9 @@ impl NoteGenerator for ArkworksPoseidonBn254NoteGenerator {
 		let secrets = match (self.exponentiation, self.width) {
 			(5, 3) => Leaf5_3::generate_secrets(&mut r).map_err(|_| OpStatusCode::SecretGenFailed)?,
 			(5, 5) => Leaf5_5::generate_secrets(&mut r).map_err(|_| OpStatusCode::SecretGenFailed)?,
-
 			(3, 3) => Leaf3_3::generate_secrets(&mut r).map_err(|_| OpStatusCode::SecretGenFailed)?,
-
 			(3, 5) => Leaf3_5::generate_secrets(&mut r).map_err(|_| OpStatusCode::SecretGenFailed)?,
-
 			(17, 3) => Leaf17_3::generate_secrets(&mut r).map_err(|_| OpStatusCode::SecretGenFailed)?,
-
 			(17, 5) => Leaf17_5::generate_secrets(&mut r).map_err(|_| OpStatusCode::SecretGenFailed)?,
 			_ => {
 				unimplemented!()
@@ -149,20 +69,21 @@ impl LeafHasher for ArkworksPoseidonBn254NoteGenerator {
 	const SECRET_LENGTH: usize = 0;
 
 	fn hash(&self, secrets: &[u8], params: Self::HasherOptions) -> Result<Vec<u8>, OpStatusCode> {
+		dbg!(secrets.len());
 		if secrets.len() != 96 {
 			return Err(OpStatusCode::InvalidNoteLength);
 		}
 		let leaf_res = match (self.exponentiation, self.width) {
-			(5, 3) => PoseidonCRH5_3::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?,
-			(5, 5) => PoseidonCRH5_5::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?,
-
-			(3, 3) => PoseidonCRH3_3::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?,
-
-			(3, 5) => PoseidonCRH3_5::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?,
-
-			(17, 3) => PoseidonCRH17_3::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?,
-
-			(17, 5) => PoseidonCRH17_5::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?,
+			(5, 3) => PoseidonCRH_x5_3::<Fr>::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?,
+			(5, 5) => PoseidonCRH_x5_5::<Fr>::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?,
+			(3, 3) => PoseidonCRH_x3_3::<Fr>::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?,
+			(3, 5) => PoseidonCRH_x3_5::<Fr>::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?,
+			(17, 3) => {
+				PoseidonCRH_x17_3::<Fr>::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?
+			}
+			(17, 5) => {
+				PoseidonCRH_x17_3::<Fr>::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?
+			}
 			_ => {
 				unimplemented!()
 			}
@@ -175,36 +96,12 @@ impl LeafHasher for ArkworksPoseidonBn254NoteGenerator {
 impl ArkworksPoseidonBn254NoteGenerator {
 	fn get_params(&self) -> PoseidonParameters<Fr> {
 		match (self.exponentiation, self.width) {
-			(5, 3) => {
-				let rounds = get_rounds_poseidon_bn254_x5_3::<Fr>();
-				let mds = get_mds_poseidon_bn254_x5_3::<Fr>();
-				PoseidonParameters::<Fr>::new(rounds, mds)
-			}
-			(5, 5) => {
-				let rounds = get_rounds_poseidon_bn254_x5_5::<Fr>();
-				let mds = get_mds_poseidon_bn254_x5_5::<Fr>();
-				PoseidonParameters::<Fr>::new(rounds, mds)
-			}
-			(3, 3) => {
-				let rounds = get_rounds_poseidon_bn254_x3_3::<Fr>();
-				let mds = get_mds_poseidon_bn254_x3_3::<Fr>();
-				PoseidonParameters::<Fr>::new(rounds, mds)
-			}
-			(3, 5) => {
-				let rounds = get_rounds_poseidon_bn254_x3_5::<Fr>();
-				let mds = get_mds_poseidon_bn254_x3_5::<Fr>();
-				PoseidonParameters::<Fr>::new(rounds, mds)
-			}
-			(17, 3) => {
-				let rounds = get_rounds_poseidon_bn254_x17_3::<Fr>();
-				let mds = get_mds_poseidon_bn254_x17_3::<Fr>();
-				PoseidonParameters::<Fr>::new(rounds, mds)
-			}
-			(17, 5) => {
-				let rounds = get_rounds_poseidon_bn254_x17_5::<Fr>();
-				let mds = get_mds_poseidon_bn254_x17_5::<Fr>();
-				PoseidonParameters::<Fr>::new(rounds, mds)
-			}
+			(5, 3) => setup_params_x3_3::<Fr>(Curve::Bn254),
+			(5, 5) => setup_params_x5_5::<Fr>(Curve::Bn254),
+			(3, 3) => setup_params_x3_3::<Fr>(Curve::Bn254),
+			(3, 5) => setup_params_x3_5::<Fr>(Curve::Bn254),
+			(17, 3) => setup_params_x17_3::<Fr>(Curve::Bn254),
+			(17, 5) => setup_params_x17_5::<Fr>(Curve::Bn254),
 			_ => {
 				unreachable!()
 			}
@@ -233,7 +130,7 @@ mod test {
 
 	#[test]
 	fn arkworks_poseidon_bn254note_generator_5x_3() {
-		let note_generator = ArkworksPoseidonBn254NoteGenerator::set_up(PoseidonRounds5_3);
+		let note_generator = ArkworksPoseidonBn254NoteGenerator::set_up(PoseidonRounds_x5_3);
 		let secrets = note_generator.generate_secrets(&mut OsRng::default()).unwrap();
 		let leaf = note_generator.hash(&secrets, note_generator.get_params()).unwrap();
 		let note = note_generator
@@ -243,7 +140,7 @@ mod test {
 	}
 	#[test]
 	fn arkworks_poseidon_bn254note_generator_5x_5() {
-		let note_generator = ArkworksPoseidonBn254NoteGenerator::set_up(PoseidonRounds5_5);
+		let note_generator = ArkworksPoseidonBn254NoteGenerator::set_up(PoseidonRounds_x5_5);
 		let secrets = note_generator.generate_secrets(&mut OsRng::default()).unwrap();
 		let leaf = note_generator.hash(&secrets, note_generator.get_params()).unwrap();
 		let note = note_generator
@@ -253,7 +150,7 @@ mod test {
 	}
 	#[test]
 	fn arkworks_poseidon_bn254note_generator_3x_3() {
-		let note_generator = ArkworksPoseidonBn254NoteGenerator::set_up(PoseidonRounds3_3);
+		let note_generator = ArkworksPoseidonBn254NoteGenerator::set_up(PoseidonRounds_x3_3);
 		let secrets = note_generator.generate_secrets(&mut OsRng::default()).unwrap();
 		let leaf = note_generator.hash(&secrets, note_generator.get_params()).unwrap();
 		let note = note_generator
@@ -263,9 +160,10 @@ mod test {
 	}
 	#[test]
 	fn arkworks_poseidon_bn254note_generator_3x_5() {
-		let note_generator = ArkworksPoseidonBn254NoteGenerator::set_up(PoseidonRounds3_5);
+		let note_generator = ArkworksPoseidonBn254NoteGenerator::set_up(PoseidonRounds_x3_5);
 		let secrets = note_generator.generate_secrets(&mut OsRng::default()).unwrap();
 		let leaf = note_generator.hash(&secrets, note_generator.get_params()).unwrap();
+		dbg!(&leaf);
 		let note = note_generator
 			.generate(&NoteBuilder::default(), &mut OsRng::default())
 			.unwrap();
@@ -273,7 +171,7 @@ mod test {
 	}
 	#[test]
 	fn arkworks_poseidon_bn254note_generator_17x_3() {
-		let note_generator = ArkworksPoseidonBn254NoteGenerator::set_up(PoseidonRounds17_3);
+		let note_generator = ArkworksPoseidonBn254NoteGenerator::set_up(PoseidonRounds_x17_3);
 		let secrets = note_generator.generate_secrets(&mut OsRng::default()).unwrap();
 		let leaf = note_generator.hash(&secrets, note_generator.get_params()).unwrap();
 		let note = note_generator
@@ -284,7 +182,7 @@ mod test {
 
 	#[test]
 	fn arkworks_poseidon_bn254note_generator_17x_5() {
-		let note_generator = ArkworksPoseidonBn254NoteGenerator::set_up(PoseidonRounds17_5);
+		let note_generator = ArkworksPoseidonBn254NoteGenerator::set_up(PoseidonRounds_x17_5);
 		let secrets = note_generator.generate_secrets(&mut OsRng::default()).unwrap();
 		let leaf = note_generator.hash(&secrets, note_generator.get_params()).unwrap();
 		let note = note_generator

--- a/packages/wasm-utils/src/arkworks_poseidon_bn254.rs
+++ b/packages/wasm-utils/src/arkworks_poseidon_bn254.rs
@@ -1,10 +1,10 @@
 use std::convert::TryInto;
 
-use crate::note::{LeafHasher, NoteGenerator, OpStatusCode};
 use ark_crypto_primitives::crh::injective_map::{PedersenCRHCompressor, TECompressor};
 use ark_crypto_primitives::CRH as CRHTrait;
 use ark_ff::fields::PrimeField;
 use ark_ff::{to_bytes, BigInteger, ToBytes};
+use arkworks_gadgets::ark_std::rand;
 use arkworks_gadgets::leaf::mixer::{MixerLeaf, Private};
 use arkworks_gadgets::leaf::LeafCreation;
 use arkworks_gadgets::poseidon::sbox::PoseidonSbox;
@@ -26,8 +26,8 @@ use arkworks_gadgets::utils::{
 	get_rounds_poseidon_bn254_x5_3, get_rounds_poseidon_bn254_x5_5,
 };
 use pedersen_hash::PedersenWindow;
-use rand::rngs::OsRng;
-use rand::Rng;
+
+use crate::note::{LeafHasher, NoteGenerator, OpStatusCode};
 
 pub struct ArkworksPoseidonBn254NoteGenerator {
 	exponentiation: usize,
@@ -42,17 +42,16 @@ type Leaf17_3 = MixerLeaf<Fr, PoseidonCRH_x17_3<Fr>>;
 
 const SEED: &[u8; 32] = b"WebbToolsPedersenHasherSeedBytes";
 impl NoteGenerator for ArkworksPoseidonBn254NoteGenerator {
-	fn generate_secrets(&self, _rng: &mut OsRng) -> Result<Vec<u8>, OpStatusCode> {
-		use arkworks_gadgets::ark_std::rand;
-		let mut r = rand::rngs::StdRng::from_seed(*SEED);
+	type Rng = rand::rngs::StdRng;
 
+	fn generate_secrets(&self, r: &mut Self::Rng) -> Result<Vec<u8>, OpStatusCode> {
 		let secrets = match (self.exponentiation, self.width) {
-			(5, 3) => Leaf5_3::generate_secrets(&mut r).map_err(|_| OpStatusCode::SecretGenFailed)?,
-			(5, 5) => Leaf5_5::generate_secrets(&mut r).map_err(|_| OpStatusCode::SecretGenFailed)?,
-			(3, 3) => Leaf3_3::generate_secrets(&mut r).map_err(|_| OpStatusCode::SecretGenFailed)?,
-			(3, 5) => Leaf3_5::generate_secrets(&mut r).map_err(|_| OpStatusCode::SecretGenFailed)?,
-			(17, 3) => Leaf17_3::generate_secrets(&mut r).map_err(|_| OpStatusCode::SecretGenFailed)?,
-			(17, 5) => Leaf17_5::generate_secrets(&mut r).map_err(|_| OpStatusCode::SecretGenFailed)?,
+			(5, 3) => Leaf5_3::generate_secrets(r).map_err(|_| OpStatusCode::SecretGenFailed)?,
+			(5, 5) => Leaf5_5::generate_secrets(r).map_err(|_| OpStatusCode::SecretGenFailed)?,
+			(3, 3) => Leaf3_3::generate_secrets(r).map_err(|_| OpStatusCode::SecretGenFailed)?,
+			(3, 5) => Leaf3_5::generate_secrets(r).map_err(|_| OpStatusCode::SecretGenFailed)?,
+			(17, 3) => Leaf17_3::generate_secrets(r).map_err(|_| OpStatusCode::SecretGenFailed)?,
+			(17, 5) => Leaf17_5::generate_secrets(r).map_err(|_| OpStatusCode::SecretGenFailed)?,
 			_ => {
 				unimplemented!()
 			}
@@ -124,70 +123,66 @@ impl ArkworksPoseidonBn254NoteGenerator {
 
 #[cfg(test)]
 mod test {
+	use arkworks_gadgets::ark_std::rand;
+
 	use crate::note::NoteBuilder;
 
 	use super::*;
 
 	#[test]
 	fn arkworks_poseidon_bn254note_generator_5x_3() {
+		let mut r = rand::rngs::StdRng::from_seed(*SEED);
 		let note_generator = ArkworksPoseidonBn254NoteGenerator::set_up(PoseidonRounds_x5_3);
-		let secrets = note_generator.generate_secrets(&mut OsRng::default()).unwrap();
+		let secrets = note_generator.generate_secrets(&mut r).unwrap();
 		let leaf = note_generator.hash(&secrets, note_generator.get_params()).unwrap();
-		let note = note_generator
-			.generate(&NoteBuilder::default(), &mut OsRng::default())
-			.unwrap();
+		let note = note_generator.generate(&NoteBuilder::default(), &mut r).unwrap();
 		dbg!(note.to_string());
 	}
 	#[test]
 	fn arkworks_poseidon_bn254note_generator_5x_5() {
+		let mut r = rand::rngs::StdRng::from_seed(*SEED);
 		let note_generator = ArkworksPoseidonBn254NoteGenerator::set_up(PoseidonRounds_x5_5);
-		let secrets = note_generator.generate_secrets(&mut OsRng::default()).unwrap();
+		let secrets = note_generator.generate_secrets(&mut r).unwrap();
 		let leaf = note_generator.hash(&secrets, note_generator.get_params()).unwrap();
-		let note = note_generator
-			.generate(&NoteBuilder::default(), &mut OsRng::default())
-			.unwrap();
+		let note = note_generator.generate(&NoteBuilder::default(), &mut r).unwrap();
 		dbg!(note.to_string());
 	}
 	#[test]
 	fn arkworks_poseidon_bn254note_generator_3x_3() {
+		let mut r = rand::rngs::StdRng::from_seed(*SEED);
 		let note_generator = ArkworksPoseidonBn254NoteGenerator::set_up(PoseidonRounds_x3_3);
-		let secrets = note_generator.generate_secrets(&mut OsRng::default()).unwrap();
+		let secrets = note_generator.generate_secrets(&mut r).unwrap();
 		let leaf = note_generator.hash(&secrets, note_generator.get_params()).unwrap();
-		let note = note_generator
-			.generate(&NoteBuilder::default(), &mut OsRng::default())
-			.unwrap();
+		let note = note_generator.generate(&NoteBuilder::default(), &mut r).unwrap();
 		dbg!(note.to_string());
 	}
 	#[test]
 	fn arkworks_poseidon_bn254note_generator_3x_5() {
+		let mut r = rand::rngs::StdRng::from_seed(*SEED);
 		let note_generator = ArkworksPoseidonBn254NoteGenerator::set_up(PoseidonRounds_x3_5);
-		let secrets = note_generator.generate_secrets(&mut OsRng::default()).unwrap();
+		let secrets = note_generator.generate_secrets(&mut r).unwrap();
 		let leaf = note_generator.hash(&secrets, note_generator.get_params()).unwrap();
 		dbg!(&leaf);
-		let note = note_generator
-			.generate(&NoteBuilder::default(), &mut OsRng::default())
-			.unwrap();
+		let note = note_generator.generate(&NoteBuilder::default(), &mut r).unwrap();
 		dbg!(note.to_string());
 	}
 	#[test]
 	fn arkworks_poseidon_bn254note_generator_17x_3() {
+		let mut r = rand::rngs::StdRng::from_seed(*SEED);
 		let note_generator = ArkworksPoseidonBn254NoteGenerator::set_up(PoseidonRounds_x17_3);
-		let secrets = note_generator.generate_secrets(&mut OsRng::default()).unwrap();
+		let secrets = note_generator.generate_secrets(&mut r).unwrap();
 		let leaf = note_generator.hash(&secrets, note_generator.get_params()).unwrap();
-		let note = note_generator
-			.generate(&NoteBuilder::default(), &mut OsRng::default())
-			.unwrap();
+		let note = note_generator.generate(&NoteBuilder::default(), &mut r).unwrap();
 		dbg!(note.to_string());
 	}
 
 	#[test]
 	fn arkworks_poseidon_bn254note_generator_17x_5() {
+		let mut r = rand::rngs::StdRng::from_seed(*SEED);
 		let note_generator = ArkworksPoseidonBn254NoteGenerator::set_up(PoseidonRounds_x17_5);
-		let secrets = note_generator.generate_secrets(&mut OsRng::default()).unwrap();
+		let secrets = note_generator.generate_secrets(&mut r).unwrap();
 		let leaf = note_generator.hash(&secrets, note_generator.get_params()).unwrap();
-		let note = note_generator
-			.generate(&NoteBuilder::default(), &mut OsRng::default())
-			.unwrap();
+		let note = note_generator.generate(&NoteBuilder::default(), &mut r).unwrap();
 		dbg!(note.to_string());
 	}
 }

--- a/packages/wasm-utils/src/arkworks_poseidon_bn254.rs
+++ b/packages/wasm-utils/src/arkworks_poseidon_bn254.rs
@@ -1,30 +1,20 @@
-use std::convert::TryInto;
-
 use ark_crypto_primitives::crh::injective_map::{PedersenCRHCompressor, TECompressor};
 use ark_crypto_primitives::CRH as CRHTrait;
 use ark_ff::fields::PrimeField;
-use ark_ff::{to_bytes, BigInteger, ToBytes};
+use ark_ff::{to_bytes, BigInteger};
 use arkworks_gadgets::ark_std::rand;
-use arkworks_gadgets::leaf::mixer::{MixerLeaf, Private};
+use arkworks_gadgets::leaf::mixer::MixerLeaf;
 use arkworks_gadgets::leaf::LeafCreation;
 use arkworks_gadgets::poseidon::sbox::PoseidonSbox;
-use arkworks_gadgets::poseidon::{PoseidonParameters, Rounds, CRH};
-use arkworks_gadgets::prelude::ark_bn254::{Bn254, Fr};
+use arkworks_gadgets::poseidon::{PoseidonParameters, Rounds};
+use arkworks_gadgets::prelude::ark_bn254::Fr;
 use arkworks_gadgets::prelude::ark_std::rand::SeedableRng;
 use arkworks_gadgets::prelude::*;
 use arkworks_gadgets::setup::common::{
 	setup_params_x17_3, setup_params_x17_5, setup_params_x3_3, setup_params_x3_5, setup_params_x5_5, Curve,
 	PoseidonCRH_x17_3, PoseidonCRH_x17_5, PoseidonCRH_x3_3, PoseidonCRH_x3_5, PoseidonCRH_x5_3, PoseidonCRH_x5_5,
-	PoseidonRounds_x17_3, PoseidonRounds_x17_5, PoseidonRounds_x3_3, PoseidonRounds_x3_5, PoseidonRounds_x5_3,
-	PoseidonRounds_x5_5,
 };
-use arkworks_gadgets::utils::{
-	get_mds_poseidon_bn254_x17_3, get_mds_poseidon_bn254_x17_5, get_mds_poseidon_bn254_x3_3,
-	get_mds_poseidon_bn254_x3_5, get_mds_poseidon_bn254_x5_3, get_mds_poseidon_bn254_x5_5,
-	get_rounds_poseidon_bls381_x3_3, get_rounds_poseidon_bls381_x3_5, get_rounds_poseidon_bn254_x17_3,
-	get_rounds_poseidon_bn254_x17_5, get_rounds_poseidon_bn254_x3_3, get_rounds_poseidon_bn254_x3_5,
-	get_rounds_poseidon_bn254_x5_3, get_rounds_poseidon_bn254_x5_5,
-};
+
 use pedersen_hash::PedersenWindow;
 
 use crate::note::{LeafHasher, NoteGenerator, OpStatusCode};
@@ -128,6 +118,10 @@ mod test {
 	use crate::note::NoteBuilder;
 
 	use super::*;
+	use arkworks_gadgets::setup::common::{
+		PoseidonRounds_x17_3, PoseidonRounds_x17_5, PoseidonRounds_x3_3, PoseidonRounds_x3_5, PoseidonRounds_x5_3,
+		PoseidonRounds_x5_5,
+	};
 
 	#[test]
 	fn arkworks_poseidon_bn254note_generator_5x_3() {

--- a/packages/wasm-utils/src/arkworks_poseidon_bn254.rs
+++ b/packages/wasm-utils/src/arkworks_poseidon_bn254.rs
@@ -1,4 +1,3 @@
-use ark_crypto_primitives::crh::injective_map::{PedersenCRHCompressor, TECompressor};
 use ark_crypto_primitives::CRH as CRHTrait;
 use ark_ff::fields::PrimeField;
 use ark_ff::{to_bytes, BigInteger};
@@ -14,8 +13,6 @@ use arkworks_gadgets::setup::common::{
 	setup_params_x17_3, setup_params_x17_5, setup_params_x3_3, setup_params_x3_5, setup_params_x5_5, Curve,
 	PoseidonCRH_x17_3, PoseidonCRH_x17_5, PoseidonCRH_x3_3, PoseidonCRH_x3_5, PoseidonCRH_x5_3, PoseidonCRH_x5_5,
 };
-
-use pedersen_hash::PedersenWindow;
 
 use crate::note::{LeafHasher, NoteGenerator, OpStatusCode};
 

--- a/packages/wasm-utils/src/arkworks_poseidon_bn254.rs
+++ b/packages/wasm-utils/src/arkworks_poseidon_bn254.rs
@@ -24,8 +24,9 @@ use rand::Rng;
 
 use crate::note::{LeafHasher, NoteGenerator, OpStatusCode};
 
-pub struct ArkworksPoseidonBn254NoteGenerator<T: Rounds> {
-	rounds: T,
+pub struct ArkworksPoseidonBn254NoteGenerator {
+	exponentiation: usize,
+	width: usize,
 }
 /// Poseidon width 3
 
@@ -116,34 +117,22 @@ type PoseidonCRH17_5 = CRH<Fr, PoseidonRounds17_5>;
 type Leaf17_5 = MixerLeaf<Fr, PoseidonCRH17_5>;
 
 const SEED: &[u8; 32] = b"WebbToolsPedersenHasherSeedBytes";
-impl<T: Rounds> NoteGenerator for ArkworksPoseidonBn254NoteGenerator<T> {
+impl NoteGenerator for ArkworksPoseidonBn254NoteGenerator {
 	fn generate_secrets(&self, _rng: &mut OsRng) -> Result<Vec<u8>, OpStatusCode> {
 		use arkworks_gadgets::ark_std::rand;
 		let mut r = rand::rngs::StdRng::from_seed(*SEED);
 
-		let secrets = match (T::SBOX, T::WIDTH) {
-			(PoseidonSbox::Exponentiation(5), 3) => {
-				Leaf5_3::generate_secrets(&mut r).map_err(|_| OpStatusCode::SecretGenFailed)?
-			}
-			(PoseidonSbox::Exponentiation(5), 5) => {
-				Leaf5_5::generate_secrets(&mut r).map_err(|_| OpStatusCode::SecretGenFailed)?
-			}
+		let secrets = match (self.exponentiation, self.width) {
+			(5, 3) => Leaf5_3::generate_secrets(&mut r).map_err(|_| OpStatusCode::SecretGenFailed)?,
+			(5, 5) => Leaf5_5::generate_secrets(&mut r).map_err(|_| OpStatusCode::SecretGenFailed)?,
 
-			(PoseidonSbox::Exponentiation(3), 3) => {
-				Leaf3_3::generate_secrets(&mut r).map_err(|_| OpStatusCode::SecretGenFailed)?
-			}
+			(3, 3) => Leaf3_3::generate_secrets(&mut r).map_err(|_| OpStatusCode::SecretGenFailed)?,
 
-			(PoseidonSbox::Exponentiation(3), 5) => {
-				Leaf3_5::generate_secrets(&mut r).map_err(|_| OpStatusCode::SecretGenFailed)?
-			}
+			(3, 5) => Leaf3_5::generate_secrets(&mut r).map_err(|_| OpStatusCode::SecretGenFailed)?,
 
-			(PoseidonSbox::Exponentiation(17), 3) => {
-				Leaf17_3::generate_secrets(&mut r).map_err(|_| OpStatusCode::SecretGenFailed)?
-			}
+			(17, 3) => Leaf17_3::generate_secrets(&mut r).map_err(|_| OpStatusCode::SecretGenFailed)?,
 
-			(PoseidonSbox::Exponentiation(17), 5) => {
-				Leaf17_5::generate_secrets(&mut r).map_err(|_| OpStatusCode::SecretGenFailed)?
-			}
+			(17, 5) => Leaf17_5::generate_secrets(&mut r).map_err(|_| OpStatusCode::SecretGenFailed)?,
 			_ => {
 				unimplemented!()
 			}
@@ -154,7 +143,7 @@ impl<T: Rounds> NoteGenerator for ArkworksPoseidonBn254NoteGenerator<T> {
 	}
 }
 
-impl<T: Rounds> LeafHasher for ArkworksPoseidonBn254NoteGenerator<T> {
+impl LeafHasher for ArkworksPoseidonBn254NoteGenerator {
 	type HasherOptions = PoseidonParameters<Fr>;
 
 	const SECRET_LENGTH: usize = 0;
@@ -163,29 +152,17 @@ impl<T: Rounds> LeafHasher for ArkworksPoseidonBn254NoteGenerator<T> {
 		if secrets.len() != 96 {
 			return Err(OpStatusCode::InvalidNoteLength);
 		}
-		let leaf_res = match (T::SBOX, T::WIDTH) {
-			(PoseidonSbox::Exponentiation(5), 3) => {
-				PoseidonCRH5_3::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?
-			}
-			(PoseidonSbox::Exponentiation(5), 5) => {
-				PoseidonCRH5_5::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?
-			}
+		let leaf_res = match (self.exponentiation, self.width) {
+			(5, 3) => PoseidonCRH5_3::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?,
+			(5, 5) => PoseidonCRH5_5::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?,
 
-			(PoseidonSbox::Exponentiation(3), 3) => {
-				PoseidonCRH3_3::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?
-			}
+			(3, 3) => PoseidonCRH3_3::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?,
 
-			(PoseidonSbox::Exponentiation(3), 5) => {
-				PoseidonCRH3_5::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?
-			}
+			(3, 5) => PoseidonCRH3_5::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?,
 
-			(PoseidonSbox::Exponentiation(17), 3) => {
-				PoseidonCRH17_3::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?
-			}
+			(17, 3) => PoseidonCRH17_3::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?,
 
-			(PoseidonSbox::Exponentiation(17), 5) => {
-				PoseidonCRH17_5::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?
-			}
+			(17, 5) => PoseidonCRH17_5::evaluate(&params, &secrets).map_err(|_| OpStatusCode::SecretGenFailed)?,
 			_ => {
 				unimplemented!()
 			}
@@ -195,35 +172,35 @@ impl<T: Rounds> LeafHasher for ArkworksPoseidonBn254NoteGenerator<T> {
 	}
 }
 
-impl<T: Rounds> ArkworksPoseidonBn254NoteGenerator<T> {
+impl ArkworksPoseidonBn254NoteGenerator {
 	fn get_params(&self) -> PoseidonParameters<Fr> {
-		match (T::SBOX, T::WIDTH) {
-			(PoseidonSbox::Exponentiation(5), 3) => {
+		match (self.exponentiation, self.width) {
+			(5, 3) => {
 				let rounds = get_rounds_poseidon_bn254_x5_3::<Fr>();
 				let mds = get_mds_poseidon_bn254_x5_3::<Fr>();
 				PoseidonParameters::<Fr>::new(rounds, mds)
 			}
-			(PoseidonSbox::Exponentiation(5), 5) => {
+			(5, 5) => {
 				let rounds = get_rounds_poseidon_bn254_x5_5::<Fr>();
 				let mds = get_mds_poseidon_bn254_x5_5::<Fr>();
 				PoseidonParameters::<Fr>::new(rounds, mds)
 			}
-			(PoseidonSbox::Exponentiation(3), 3) => {
+			(3, 3) => {
 				let rounds = get_rounds_poseidon_bn254_x3_3::<Fr>();
 				let mds = get_mds_poseidon_bn254_x3_3::<Fr>();
 				PoseidonParameters::<Fr>::new(rounds, mds)
 			}
-			(PoseidonSbox::Exponentiation(3), 5) => {
+			(3, 5) => {
 				let rounds = get_rounds_poseidon_bn254_x3_5::<Fr>();
 				let mds = get_mds_poseidon_bn254_x3_5::<Fr>();
 				PoseidonParameters::<Fr>::new(rounds, mds)
 			}
-			(PoseidonSbox::Exponentiation(17), 3) => {
+			(17, 3) => {
 				let rounds = get_rounds_poseidon_bn254_x17_3::<Fr>();
 				let mds = get_mds_poseidon_bn254_x17_3::<Fr>();
 				PoseidonParameters::<Fr>::new(rounds, mds)
 			}
-			(PoseidonSbox::Exponentiation(17), 5) => {
+			(17, 5) => {
 				let rounds = get_rounds_poseidon_bn254_x17_5::<Fr>();
 				let mds = get_mds_poseidon_bn254_x17_5::<Fr>();
 				PoseidonParameters::<Fr>::new(rounds, mds)
@@ -234,8 +211,17 @@ impl<T: Rounds> ArkworksPoseidonBn254NoteGenerator<T> {
 		}
 	}
 
-	fn set_up(rounds: T) -> Self {
-		Self { rounds }
+	fn set_up<T: Rounds>(_: T) -> Self {
+		let exponentiation = match T::SBOX {
+			PoseidonSbox::Exponentiation(e) => e,
+			PoseidonSbox::Inverse => {
+				unreachable!()
+			}
+		};
+		Self {
+			exponentiation,
+			width: T::WIDTH,
+		}
 	}
 }
 

--- a/packages/wasm-utils/src/bulletproof_posidon_25519.rs
+++ b/packages/wasm-utils/src/bulletproof_posidon_25519.rs
@@ -1,6 +1,5 @@
 use crate::note::{LeafHasher, NoteGenerator, OpStatusCode};
-use bulletproofs::{BulletproofGens, PedersenGens};
-use bulletproofs_gadgets::poseidon::builder::{Poseidon, PoseidonBuilder};
+use bulletproofs_gadgets::poseidon::builder::Poseidon;
 use bulletproofs_gadgets::poseidon::Poseidon_hash_2;
 use curve25519_dalek::scalar::Scalar;
 use rand::rngs::OsRng;

--- a/packages/wasm-utils/src/bulletproof_posidon_25519.rs
+++ b/packages/wasm-utils/src/bulletproof_posidon_25519.rs
@@ -33,7 +33,9 @@ impl LeafHasher for PoseidonNoteGeneratorCurve25519 {
 }
 
 impl NoteGenerator for PoseidonNoteGeneratorCurve25519 {
-	fn generate_secrets(&self, rng: &mut OsRng) -> Result<Vec<u8>, OpStatusCode> {
+	type Rng = OsRng;
+
+	fn generate_secrets(&self, rng: &mut Self::Rng) -> Result<Vec<u8>, OpStatusCode> {
 		let mut r: [u8; 32] = [0; 32];
 		let mut nullifier = [0u8; 32];
 		rng.fill(&mut r);

--- a/packages/wasm-utils/src/lib.rs
+++ b/packages/wasm-utils/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 mod arkworks_poseidon_bls12_381;
 mod arkworks_poseidon_bn254;
 mod bulletproof_posidon_25519;
@@ -560,7 +562,7 @@ impl PedersonNoteGenerator {
 		}
 	}
 
-	pub fn leaf_of(&self, note: &Note) -> Uint8Array {
+	pub fn leaf_of(&self, _note: &Note) -> Uint8Array {
 		unimplemented!()
 	}
 

--- a/packages/wasm-utils/src/note.rs
+++ b/packages/wasm-utils/src/note.rs
@@ -13,7 +13,7 @@ use bulletproofs_gadgets::poseidon::{PoseidonSbox, Poseidon_hash_2};
 use curve25519_dalek::scalar::Scalar;
 use pedersen_hash::PedersenWindow;
 use rand::rngs::OsRng;
-use rand::Rng;
+use rand::{CryptoRng, Rng};
 
 use crate::PoseidonHasher;
 
@@ -178,8 +178,9 @@ pub enum NoteVersion {
 	V1,
 }
 pub trait NoteGenerator {
-	fn generate_secrets(&self, r: &mut OsRng) -> Result<Vec<u8>, OpStatusCode>;
-	fn generate(&self, note_builder: &NoteBuilder, r: &mut OsRng) -> Result<Note, OpStatusCode> {
+	type Rng;
+	fn generate_secrets(&self, r: &mut Self::Rng) -> Result<Vec<u8>, OpStatusCode>;
+	fn generate(&self, note_builder: &NoteBuilder, r: &mut Self::Rng) -> Result<Note, OpStatusCode> {
 		let secrets = Self::generate_secrets(self, r).map_err(|_| OpStatusCode::SecretGenFailed)?;
 		Ok(Note {
 			prefix: note_builder.prefix.clone(),

--- a/packages/wasm-utils/src/note.rs
+++ b/packages/wasm-utils/src/note.rs
@@ -1,11 +1,8 @@
 use core::fmt;
-use std::convert::{TryFrom, TryInto};
-use std::marker::PhantomData;
+use std::convert::TryInto;
 use std::str::FromStr;
 
-use bulletproofs::{BulletproofGens, PedersenGens};
-
-use crate::PoseidonHasher;
+use bulletproofs::BulletproofGens;
 
 const FULL_NOTE_LENGTH: usize = 11;
 const NOTE_PREFIX: &str = "webb.mix";

--- a/packages/wasm-utils/src/note.rs
+++ b/packages/wasm-utils/src/note.rs
@@ -1,5 +1,4 @@
 use core::fmt;
-use std::convert::TryInto;
 use std::str::FromStr;
 
 use bulletproofs::BulletproofGens;
@@ -171,15 +170,15 @@ pub trait NoteGenerator {
 		let secrets = Self::generate_secrets(self, r).map_err(|_| OpStatusCode::SecretGenFailed)?;
 		Ok(Note {
 			prefix: note_builder.prefix.clone(),
-			version: note_builder.version.clone(),
+			version: note_builder.version,
 			chain: note_builder.chain.clone(),
-			backend: note_builder.backend.clone(),
-			curve: note_builder.curve.clone(),
-			hash_function: note_builder.hash_function.clone(),
+			backend: note_builder.backend,
+			curve: note_builder.curve,
+			hash_function: note_builder.hash_function,
 			token_symbol: note_builder.token_symbol.clone(),
 			amount: note_builder.amount.clone(),
 			denomination: note_builder.denomination.clone(),
-			group_id: note_builder.group_id.clone(),
+			group_id: note_builder.group_id,
 			secret: secrets,
 		})
 	}
@@ -283,7 +282,7 @@ impl Note {
 impl fmt::Display for Note {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		let secrets = hex::encode(&self.secret);
-		let mut parts: Vec<String> = vec![
+		let parts: Vec<String> = vec![
 			//0 => prefix
 			self.prefix.clone(),
 			//1 => version
@@ -293,7 +292,7 @@ impl fmt::Display for Note {
 			//3 => group_id
 			format!("{}", self.group_id),
 			//4
-			format!("{}", secrets),
+			secrets,
 			//5 => curve
 			self.curve.to_string(),
 			//6 => hash_function
@@ -330,13 +329,10 @@ impl FromStr for Note {
 		let token_symbol = parts[2].to_owned();
 		let group_id = parts[3].parse().map_err(|_| OpStatusCode::InvalidNoteId)?;
 		let note_val = parts[4];
-		if note_val.len() == 0 {
+		if note_val.is_empty() {
 			return Err(OpStatusCode::InvalidNoteSecrets);
 		}
-		let secret: Vec<u8> = hex::decode(&note_val)
-			.map(|v| v.try_into())
-			.map_err(|_| OpStatusCode::InvalidHexLength)?
-			.map_err(|_| OpStatusCode::HexParsingFailed)?;
+		let secret: Vec<u8> = hex::decode(&note_val).map_err(|_| OpStatusCode::HexParsingFailed)?;
 		let curve: Curve = parts[5].parse()?;
 		let hash_function: HashFunction = parts[6].parse()?;
 		let backend: Backend = parts[7].parse()?;

--- a/packages/wasm-utils/src/note.rs
+++ b/packages/wasm-utils/src/note.rs
@@ -3,17 +3,7 @@ use std::convert::{TryFrom, TryInto};
 use std::marker::PhantomData;
 use std::str::FromStr;
 
-use ark_crypto_primitives::crh::injective_map::{PedersenCRHCompressor, TECompressor};
-use ark_ed_on_bn254::EdwardsProjective;
-use arkworks_gadgets::leaf::mixer::MixerLeaf;
-use arkworks_gadgets::prelude::ark_bls12_381::Fq;
 use bulletproofs::{BulletproofGens, PedersenGens};
-use bulletproofs_gadgets::poseidon::builder::{Poseidon, PoseidonBuilder};
-use bulletproofs_gadgets::poseidon::{PoseidonSbox, Poseidon_hash_2};
-use curve25519_dalek::scalar::Scalar;
-use pedersen_hash::PedersenWindow;
-use rand::rngs::OsRng;
-use rand::{CryptoRng, Rng};
 
 use crate::PoseidonHasher;
 

--- a/packages/wasm-utils/src/types.rs
+++ b/packages/wasm-utils/src/types.rs
@@ -1,7 +1,5 @@
 use super::*;
 use core::fmt;
-use std::convert::{TryFrom, TryInto};
-use std::marker::PhantomData;
 use std::str::FromStr;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -39,7 +37,6 @@ pub enum HashFunction {
 	Poseidon17,
 	MiMCTornado,
 }
-
 
 impl fmt::Display for Backend {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
- [x]  Use poseidon round structs from `arkworks-gadgets`
- [x]  Use exposed parameter getters functions in `setup/common`
- [x]  Get rid of generic round parameters from traits/structs.
- [x]  Instead of OsRng, try to use `<R: CryptoRng>`
    - [x]  `(rng: R)`