### PR TITLE
Add wasm-utils as a dependency to sdk-core

### DIFF
--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@types/events": "^3.0.0",
     "@webb-tools/api": "^0.1.4-11",
+    "@webb-tools/wasm-utils": "^0.1.4-11",
     "bignumber.js": "^9.0.0",
     "events": "^3.2.0",
     "lodash": "^4.17.20"


### PR DESCRIPTION
While cleaning up webb-dapp of old dependencies and updating subpackages to webb.js ^0.4.11, I got an error:
`Can't resolve '@webb-tools/wasm-utils' in '/Users/nathanbarnavon/workspace/webb-dapp/node_modules/@webb-tools/sdk-core'`

I believe this should fix the issue