### PR TITLE
Expose mixer/anchor proof (public inputs) & leaf

### DIFF
--- a/packages/sdk-core/src/proving/arkworks/proving-manager-thread.ts
+++ b/packages/sdk-core/src/proving/arkworks/proving-manager-thread.ts
@@ -91,8 +91,10 @@ export class ArkworksProvingManagerThread {
       const proof = proofOutput.mixerProof;
 
       const mixerProof: WorkerProofInterface<'mixer'> = {
+        leaf: proof.leaf,
         nullifierHash: proof.nullifierHash,
         proof: proof.proof,
+        publicInputs: proof.publicInputs,
         root: proof.root
       };
 
@@ -116,8 +118,10 @@ export class ArkworksProvingManagerThread {
       const proofOutput = await this.generateProof(proofInput);
       const proof = proofOutput.anchorProof;
       const anchorProof: WorkerProofInterface<'anchor'> = {
+        leaf: proof.leaf,
         nullifierHash: proof.nullifierHash,
         proof: proof.proof,
+        publicInputs: proof.publicInputs,
         root: proof.root,
         roots: proof.roots
       };

--- a/packages/sdk-core/src/proving/circom/proving-manager-thread.ts
+++ b/packages/sdk-core/src/proving/circom/proving-manager-thread.ts
@@ -54,7 +54,7 @@ export class CircomProvingManagerThread {
       const nullifier = '0x' + noteSecretParts[1];
       const secret = '0x' + noteSecretParts[2];
       const nullifierHash = BigNumber.from(poseidon([nullifier, nullifier]));
-
+      const leaf = note.getLeafCommitment();
       // Generate the merkle proof from the passed leaves
       const mt = new MerkleTree(this.treeDepth, input.leaves.map((u8a) => u8aToHex(u8a)));
       const merkleProof = mt.path(input.leafIndex);
@@ -77,12 +77,14 @@ export class CircomProvingManagerThread {
       );
 
       const witness = await witnessCalculator.calculateWTNSBin(witnessInput, 0);
-
+      // TODO: return the public inputs
       const proofEncoded = await this.snarkjsProveAndVerify(input.provingKey, witness);
 
       const anchorProof: WorkerProofInterface<'anchor'> = {
+        leaf,
         nullifierHash: nullifierHash.toHexString(),
         proof: `0x${proofEncoded}`,
+        publicInputs: [],
         root: merkleProof.merkleRoot.toHexString(),
         roots: input.roots.map((root) => u8aToHex(root))
       };

--- a/packages/sdk-core/src/proving/types.ts
+++ b/packages/sdk-core/src/proving/types.ts
@@ -119,10 +119,14 @@ export type AnchorProof = {
   readonly proof: string;
   readonly root: string;
   readonly roots: Array<string>;
+  readonly publicInputs: Array<string>;
+  readonly leaf: Uint8Array
 };
 
 export type MixerProof = {
   readonly nullifierHash: string;
   readonly proof: string;
   readonly root: string;
+  readonly publicInputs: Array<string>;
+  readonly leaf: Uint8Array
 };

--- a/packages/wasm-utils/src/proof/mod.rs
+++ b/packages/wasm-utils/src/proof/mod.rs
@@ -187,6 +187,24 @@ impl MixerProof {
 		let root = hex::encode(&self.root);
 		root.into()
 	}
+
+	#[wasm_bindgen(getter)]
+	#[wasm_bindgen(js_name = publicInputs)]
+	pub fn public_inputs_raw(&self) -> Array {
+		let inputs: Array = self
+			.public_inputs
+			.iter()
+			.map(|x| JsString::from(hex::encode(x)))
+			.collect();
+		inputs
+	}
+
+	#[wasm_bindgen(getter)]
+	#[wasm_bindgen(js_name = leaf)]
+	pub fn leaf(&self) -> Uint8Array {
+		let leaf = Uint8Array::from(self.leaf.as_slice());
+		leaf
+	}
 }
 
 #[wasm_bindgen]
@@ -231,6 +249,24 @@ impl AnchorProof {
 	pub fn roots(&self) -> Array {
 		let roots: Array = self.roots.iter().map(|i| JsString::from(hex::encode(i))).collect();
 		roots
+	}
+
+	#[wasm_bindgen(getter)]
+	#[wasm_bindgen(js_name = publicInputs)]
+	pub fn public_inputs_raw(&self) -> Array {
+		let inputs: Array = self
+			.public_inputs
+			.iter()
+			.map(|x| JsString::from(hex::encode(x)))
+			.collect();
+		inputs
+	}
+
+	#[wasm_bindgen(getter)]
+	#[wasm_bindgen(js_name = leaf)]
+	pub fn leaf(&self) -> Uint8Array {
+		let leaf = Uint8Array::from(self.leaf.as_slice());
+		leaf
 	}
 }
 


### PR DESCRIPTION
# Overview
This PR exposes the public inputs for proof generation for the `mixer` and `anchor` 

Another PR is required to fix the (In the meantime this isn't needed as this PR is made for verifying substrate-based mixer proof)
` const proofEncoded = await this.snarkjsProveAndVerify(input.provingKey, witness);` to return the public inputs


the fix would  like

```typescript

  async snarkjsProveAndVerify (provingKey: Uint8Array, witness: any): Promise<string> {
    let res = await snarkjs.groth16.prove(provingKey, witness);

    const proof = res.proof;
    const publicSignals = res.publicSignals;

    const vKey = await snarkjs.zKey.exportVerificationKey(provingKey);

    res = await snarkjs.groth16.verify(vKey, publicSignals, proof);

    const proofBytes = await generateWithdrawProofCallData(proof, publicSignals);
    return {
    proofBytes,
    publicInputs:res.publicSignals
    }
  }