### PR TITLE
Move TypedChainId to webb.js

### DIFF
--- a/packages/sdk-core/src/__test__/typed-chain-id.spec.ts
+++ b/packages/sdk-core/src/__test__/typed-chain-id.spec.ts
@@ -3,7 +3,7 @@
 
 import { expect } from 'chai';
 
-import { byteArrayToNum, calculateTypedChainId, ChainType, numToByteArray, parseTypedChainId, TypedChainId } from '../typed-chain-id';
+import { byteArrayToNum, calculateTypedChainId, ChainType, numToByteArray, parseTypedChainId, TypedChainId } from '../typed-chain-id.js';
 
 describe('test various conversion functions', () => {
   it('byte array to num converts correctly', () => {

--- a/packages/sdk-core/src/__test__/typed-chain-id.spec.ts
+++ b/packages/sdk-core/src/__test__/typed-chain-id.spec.ts
@@ -1,0 +1,59 @@
+// Copyright 2022 Webb Technologies Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect } from 'chai';
+
+import { byteArrayToNum, calculateTypedChainId, ChainType, numToByteArray, parseTypedChainId, TypedChainId } from '../typed-chain-id';
+
+describe('test various conversion functions', () => {
+  it('byte array to num converts correctly', () => {
+    const arr = [2, 0, 0, 0, 122, 105];
+    const result = 2199023286889;
+
+    expect(byteArrayToNum(arr)).to.deep.equal(result);
+  });
+
+  it('numToByteArray converts correctly', () => {
+    const arrResult = [2, 0, 0, 0, 122, 105];
+    const number = 2199023286889;
+
+    expect(numToByteArray(number, 4)).to.deep.equal(arrResult);
+  });
+
+  it('numToByteArray converts hexstring values correctly', () => {
+    const evmResult = [1, 0];
+
+    expect(numToByteArray(ChainType.EVM, 2)).to.deep.equal(evmResult);
+    const kusamaParachainResult = [3, 17];
+
+    expect(numToByteArray(ChainType.KusamaParachain, 2)).to.deep.equal(kusamaParachainResult);
+  });
+
+  it('numToByteArray maintains minimum size with leading zeroes', () => {
+    const arrResult = [0, 0, 122, 105];
+    const number = 31337;
+
+    expect(numToByteArray(number, 4)).to.deep.equal(arrResult);
+  });
+
+  it('calculateTypedChainId converts correctly', () => {
+    const chainType = ChainType.Substrate;
+    const chainId = 31337;
+    const chainIdTypeResult = 2199023286889;
+
+    expect(calculateTypedChainId(chainType, chainId)).to.deep.equal(chainIdTypeResult);
+  });
+
+  it('typeAndIdFromChainIdType converts correctly', () => {
+    const chainIdType = 2199023286889;
+    const chainTypeResult = ChainType.Substrate;
+    const chainIdResult = 31337;
+
+    const result: TypedChainId = {
+      chainId: chainIdResult,
+      chainType: chainTypeResult
+    };
+
+    expect(parseTypedChainId(chainIdType)).to.deep.equal(result);
+  });
+});

--- a/packages/sdk-core/src/index.ts
+++ b/packages/sdk-core/src/index.ts
@@ -10,3 +10,4 @@ export * from './big-number-utils.js';
 export * from './keypair.js';
 export * from './solidity-utils/index.js';
 export * from './utxo.js';
+export * from './typed-chain-id.js';

--- a/packages/sdk-core/src/typed-chain-id.ts
+++ b/packages/sdk-core/src/typed-chain-id.ts
@@ -1,0 +1,68 @@
+// Copyright 2022 Webb Technologies Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Each ChainType has its own namespace of ChainIDs.
+export enum ChainType {
+  None = 0x0000,
+  EVM = 0x0100,
+  Substrate = 0x0200,
+  SubstrateDevelopment = 0x0250,
+  PolkadotRelayChain = 0x0301,
+  KusamaRelayChain = 0x0302,
+  PolkadotParachain = 0x0310,
+  KusamaParachain = 0x0311,
+}
+
+export type TypedChainId = {
+  chainType: ChainType;
+  chainId: number;
+}
+
+/**
+ * @param num - the number to be converted
+ * @param min - the minimum bytes the array should hold (in the case of requiring empty bytes to match rust values)
+ * @returns
+ */
+export const numToByteArray = (num: number, min: number): number[] => {
+  let arr = [];
+
+  while (num > 0) {
+    arr.push(num % 256);
+    num = Math.floor(num / 256);
+  }
+
+  arr.reverse();
+
+  // maintain minimum number of bytes
+  while (arr.length < min) {
+    arr = [0, ...arr];
+  }
+
+  return arr;
+};
+
+export const byteArrayToNum = (arr: number[]): number => {
+  let n = 0;
+
+  for (const i of arr) {
+    n = n * 256 + i;
+  }
+
+  return n;
+};
+
+export const calculateTypedChainId = (chainType: ChainType, chainId: number): number => {
+  const chainTypeArray = numToByteArray(chainType, 2);
+  const chainIdArray = numToByteArray(chainId, 4);
+  const fullArray = [...chainTypeArray, ...chainIdArray];
+
+  return byteArrayToNum(fullArray);
+};
+
+export const parseTypedChainId = (chainIdType: number): TypedChainId => {
+  const byteArray = numToByteArray(chainIdType, 4);
+  const chainType = byteArrayToNum(byteArray.slice(0, 2));
+  const chainId = byteArrayToNum(byteArray.slice(2));
+
+  return { chainId, chainType };
+};


### PR DESCRIPTION
This will expose the TypedChainId in our sdk-core. Similar to what is done in webb-rs: https://github.com/webb-tools/webb-rs/blob/main/proposals/src/header.rs#L59