### PR TITLE
Enable utxo creation and proof generation from Keypairs with only Pubkey config

### DIFF
--- a/packages/sdk-core/src/keypair.ts
+++ b/packages/sdk-core/src/keypair.ts
@@ -61,7 +61,7 @@ export class Keypair {
   }
 
   toString () {
-    return toFixedHex(this.pubkey) + Buffer.from(this.encryptionKey, 'base64').toString('hex');
+    return toFixedHex(this.pubkey) + toFixedHex(Buffer.from(this.encryptionKey, 'base64').toString('hex'));
   }
 
   /**

--- a/packages/sdk-core/src/keypair.ts
+++ b/packages/sdk-core/src/keypair.ts
@@ -123,15 +123,4 @@ export class Keypair {
   decrypt (data: string) {
     return Buffer.from(decrypt(unpackEncryptedMessage(data), this.privkey.slice(2)), 'base64');
   }
-
-  /**
-   * Sign a message using keypair private key
-   *
-   * @param commitment - a decimal string of the commitment
-   * @param merkleIndex - a number for the merkle index.
-   * @returns a decimal string representing the poseidon hash of [privKey, commitment, merkleIndex]
-   */
-  sign (commitment: string, merkleIndex: number): string {
-    return BigNumber.from(poseidon([this.privkey, commitment, merkleIndex])).toString();
-  }
 }

--- a/packages/sdk-core/src/solidity-utils/circom-utxo.ts
+++ b/packages/sdk-core/src/solidity-utils/circom-utxo.ts
@@ -196,7 +196,7 @@ export class CircomUtxo extends Utxo {
       u8aToHex(this.commitment),
       this.index > 0 ? this.index : 0,
       // The following parameter is the 'ownership hash', a portion of the nullifier that enables
-      // compliance, and ties a utxo to a particular keypair.
+      // compliance and ties a utxo to a particular keypair.
       poseidon([this.keypair.privkey, this.commitment, this.index])
     ]);
 

--- a/packages/sdk-core/src/solidity-utils/variable-anchor.ts
+++ b/packages/sdk-core/src/solidity-utils/variable-anchor.ts
@@ -6,7 +6,6 @@ import { u8aToHex } from '@polkadot/util';
 
 import { FIELD_SIZE, toFixedHex } from '../big-number-utils.js';
 import { MerkleProof, MerkleTree, Utxo } from '../index.js';
-import { Keypair } from '../keypair.js';
 
 export function getVAnchorExtDataHash (
   encryptedOutput1: string,
@@ -48,9 +47,6 @@ export function generateVariableWitnessInput (
   extDataHash: BigNumber,
   externalMerkleProofs: MerkleProof[]
 ): any {
-  const keypair1 = new Keypair(outputs[0].secret_key);
-  const keypair2 = new Keypair(outputs[1].secret_key);
-
   const vanchorMerkleProofs = externalMerkleProofs.map((proof) => ({
     pathIndex: MerkleTree.calculateIndexFromPathIndices(proof.pathIndices),
     pathElements: proof.pathElements
@@ -74,7 +70,7 @@ export function generateVariableWitnessInput (
     // data for 2 transaction outputs
     outChainID: outputs.map((x) => x.chainId),
     outAmount: outputs.map((x) => x.amount.toString()),
-    outPubkey: [toFixedHex(keypair1.pubkey), toFixedHex(keypair2.pubkey)],
+    outPubkey: outputs.map((x) => x.keypair?.pubkey),
     outBlinding: outputs.map((x) => BigNumber.from(x.blinding).toString())
   };
 

--- a/packages/sdk-core/src/utxo.ts
+++ b/packages/sdk-core/src/utxo.ts
@@ -146,6 +146,10 @@ export class Utxo {
     return this.inner.commitment;
   }
 
+  createCommitmentWithPubkey (pubkey: string): Uint8Array {
+    throw new Error('Cannot create commitment with a passed public key');
+  }
+
   /**
    * @returns the index configured on this UTXO. Output UTXOs generated
    * before they have been inserted in a tree.

--- a/packages/wasm-utils/src/note/mod.rs
+++ b/packages/wasm-utils/src/note/mod.rs
@@ -807,8 +807,6 @@ mod test {
 	use ark_bn254;
 	use wasm_bindgen_test::*;
 
-	use crate::utils::to_rust_string;
-
 	use super::*;
 
 	type Bn254Fr = ark_bn254::Fr;


### PR DESCRIPTION
When we create a proof, we are spending input utxos and generating output utxos.  This PR is needed to enable transfers.  So someone can generate an output utxo which is spendable by someone else, while not knowing the private key themselves.