### PR TITLE
Fix Failing Substrate Vanchor Test

### DIFF
--- a/tests/integration_tests/substrate/vanchorTests.spec.ts
+++ b/tests/integration_tests/substrate/vanchorTests.spec.ts
@@ -29,6 +29,8 @@ let nodes: KillTask | undefined;
 
 const BOBPhrase = 'asthma early danger glue satisfy spatial decade wing organ bean census announce';
 
+const assetId = new Uint8Array([254, 255, 255, 255]);
+
 function getKeys() {
   const pkPath = path.join(
     // tests path
@@ -168,7 +170,7 @@ async function basicDeposit(
     extAmount: extAmount.toString(),
     fee: fee.toString(),
     refund: '0',
-    token: decodedAddress
+    token: assetId
   };
   const data = await provingManager.prove('vanchor', setup) as VAnchorProof;
   const extData = {
@@ -177,7 +179,7 @@ async function basicDeposit(
     fee,
     extAmount: extAmount,
     refund: '0',
-    token: address,
+    token: assetId,
     encryptedOutput1: u8aToHex(comEnc1),
     encryptedOutput2: u8aToHex(comEnc2)
   };
@@ -267,7 +269,7 @@ async function basicWithdraw(
     extAmount: extAmount.toString(),
     fee: fee.toString(),
     refund: '0',
-    token: decodedAddress
+    token: assetId
   };
   const data = await provingManager.prove('vanchor', setup) as VAnchorProof;
   const extData = {
@@ -276,7 +278,7 @@ async function basicWithdraw(
     fee,
     extAmount: extAmount,
     refund: '0',
-    token: address,
+    token: assetId,
     encryptedOutput1: u8aToHex(comEnc1),
     encryptedOutput2: u8aToHex(comEnc2)
   };
@@ -356,7 +358,7 @@ async function createVAnchorWithDeposit(
     extAmount: extAmount.toString(),
     fee: fee.toString(),
     refund: '0',
-    token: decodedAddress
+    token: assetId
   };
   const data = await provingManager.prove('vanchor', setup) as VAnchorProof;
   const extData = {
@@ -365,7 +367,7 @@ async function createVAnchorWithDeposit(
     fee,
     extAmount: extAmount,
     refund: '0',
-    token: address,
+    token: assetId,
     encryptedOutput1: u8aToHex(comEnc1),
     encryptedOutput2: u8aToHex(comEnc2)
   };
@@ -498,7 +500,7 @@ describe('VAnchor tests', function() {
       extAmount: extAmount.toString(),
       fee: fee.toString(),
       refund: '0',
-      token: decodedAddress
+      token: assetId
     };
   const data = await provingManager.prove('vanchor', setup) as VAnchorProof;
     const extData = {
@@ -507,7 +509,7 @@ describe('VAnchor tests', function() {
       fee,
       extAmount: extAmount,
       refund: '0',
-      token: address,
+      token: assetId,
       encryptedOutput1: u8aToHex(comEnc1),
       encryptedOutput2: u8aToHex(comEnc2),
     };
@@ -590,7 +592,7 @@ describe('VAnchor tests', function() {
       extAmount: extAmount.toString(),
       fee: fee.toString(),
       refund: '0',
-      token: decodedAddress
+      token: assetId
     };
     const data = await provingManager.prove('vanchor', setup) as VAnchorProof;
     const extData = {
@@ -599,7 +601,7 @@ describe('VAnchor tests', function() {
       fee,
       extAmount: extAmount,
       refund: '0',
-      token: address,
+      token: assetId,
       encryptedOutput1: u8aToHex(comEnc1),
       encryptedOutput2: u8aToHex(comEnc2)
     };
@@ -677,7 +679,7 @@ describe('VAnchor tests', function() {
       extAmount: extAmount.toString(),
       fee: fee.toString(),
       refund: '0',
-      token: decodedAddress
+      token: assetId
     };
     const data = await provingManager.prove('vanchor', setup) as VAnchorProof;
     const extData = {
@@ -686,7 +688,7 @@ describe('VAnchor tests', function() {
       fee,
       extAmount: extAmount,
       refund: '0',
-      token: address,
+      token: assetId,
       encryptedOutput1: u8aToHex(comEnc1),
       encryptedOutput2: u8aToHex(comEnc2)
     };


### PR DESCRIPTION
## Summary of changes
- This PR slight change includes asset id as the token for `ext_data` in protocol substrate vanchor test