### PR TITLE
Semar/remove element merkle tree

### DIFF
--- a/packages/sdk-core/src/__test__/merkle-tree.spec.ts
+++ b/packages/sdk-core/src/__test__/merkle-tree.spec.ts
@@ -66,6 +66,46 @@ describe('Merkle Tree tests', () => {
     });
   });
 
+  describe('removal tests', () => {
+    let singleTree: MerkleTree
+    let bulkTree: MerkleTree
+    before(async () => {
+      singleTree = new MerkleTree(6);
+      bulkTree = new MerkleTree(6);
+
+      bulkTree.bulkInsert(elements);
+
+      for (const el of elements) {
+        singleTree.insert(el);
+      }
+
+      for (let i = 0; i < elements.length; i++) {
+        const bulkPath = bulkTree.path(i);
+        const singlePath = singleTree.path(i);
+
+        expect(bulkPath.merkleRoot.toHexString()).to.eq(singlePath.merkleRoot.toHexString());
+        expect(bulkPath.element.toHexString()).to.eq(singlePath.element.toHexString());
+        expect(bulkPath.pathIndices).to.eql(singlePath.pathIndices);
+        expect(bulkPath.pathElements).to.eql(singlePath.pathElements);
+      }
+    })
+
+    it('should evaluate the same for removeBulk and single remove', () => {
+      bulkTree.bulkRemove(elements);
+
+      for (const el of elements) {
+        singleTree.remove(el);
+      }
+
+      // for (let i = 0; i < elements.length; i++) {
+      //   // expect(bulkPath.element.toHexString()).to.eq(singlePath.element.toHexString());
+      //   // expect(bulkPath.pathIndices).to.eql(singlePath.pathIndices);
+      //   // expect(bulkPath.pathElements).to.eql(singlePath.pathElements);
+      // }
+      expect(bulkTree.root().toHexString()).to.eq(singleTree.root().toHexString());
+    });
+  });
+
   it('should correctly calculate the index from pathIndices', () => {
     const pathIndices = [0, 1, 1, 0, 1];
     const calculatedIndex = MerkleTree.calculateIndexFromPathIndices(pathIndices);

--- a/packages/sdk-core/src/__test__/merkle-tree.spec.ts
+++ b/packages/sdk-core/src/__test__/merkle-tree.spec.ts
@@ -74,7 +74,7 @@ describe('Merkle Tree tests', () => {
     before(async () => {
       singleTree = new MerkleTree(6);
       bulkTree = new MerkleTree(6);
-      initialRoot = singleTree.root()
+      initialRoot = singleTree.root();
 
       bulkTree.bulkInsert(elements);
 

--- a/packages/sdk-core/src/__test__/merkle-tree.spec.ts
+++ b/packages/sdk-core/src/__test__/merkle-tree.spec.ts
@@ -67,8 +67,9 @@ describe('Merkle Tree tests', () => {
   });
 
   describe('removal tests', () => {
-    let singleTree: MerkleTree
-    let bulkTree: MerkleTree
+    let singleTree: MerkleTree;
+    let bulkTree: MerkleTree;
+
     before(async () => {
       singleTree = new MerkleTree(6);
       bulkTree = new MerkleTree(6);
@@ -88,7 +89,7 @@ describe('Merkle Tree tests', () => {
         expect(bulkPath.pathIndices).to.eql(singlePath.pathIndices);
         expect(bulkPath.pathElements).to.eql(singlePath.pathElements);
       }
-    })
+    });
 
     it('should evaluate the same for removeBulk and single remove', () => {
       bulkTree.bulkRemove(elements);
@@ -106,6 +107,7 @@ describe('Merkle Tree tests', () => {
         expect(bulkPath.pathIndices).to.eql(singlePath.pathIndices);
         expect(bulkPath.pathElements).to.eql(singlePath.pathElements);
       }
+
       expect(bulkTree.root().toHexString()).to.eq(singleTree.root().toHexString());
     });
   });

--- a/packages/sdk-core/src/__test__/merkle-tree.spec.ts
+++ b/packages/sdk-core/src/__test__/merkle-tree.spec.ts
@@ -97,11 +97,15 @@ describe('Merkle Tree tests', () => {
         singleTree.remove(el);
       }
 
-      // for (let i = 0; i < elements.length; i++) {
-      //   // expect(bulkPath.element.toHexString()).to.eq(singlePath.element.toHexString());
-      //   // expect(bulkPath.pathIndices).to.eql(singlePath.pathIndices);
-      //   // expect(bulkPath.pathElements).to.eql(singlePath.pathElements);
-      // }
+      for (let i = 0; i < elements.length; i++) {
+        const bulkPath = bulkTree.path(i);
+        const singlePath = singleTree.path(i);
+
+        expect(bulkPath.merkleRoot.toHexString()).to.eq(singlePath.merkleRoot.toHexString());
+        expect(bulkPath.element.toHexString()).to.eq(singlePath.element.toHexString());
+        expect(bulkPath.pathIndices).to.eql(singlePath.pathIndices);
+        expect(bulkPath.pathElements).to.eql(singlePath.pathElements);
+      }
       expect(bulkTree.root().toHexString()).to.eq(singleTree.root().toHexString());
     });
   });

--- a/packages/sdk-core/src/__test__/merkle-tree.spec.ts
+++ b/packages/sdk-core/src/__test__/merkle-tree.spec.ts
@@ -69,10 +69,12 @@ describe('Merkle Tree tests', () => {
   describe('removal tests', () => {
     let singleTree: MerkleTree;
     let bulkTree: MerkleTree;
+    let initialRoot: any; // BigNumber
 
     before(async () => {
       singleTree = new MerkleTree(6);
       bulkTree = new MerkleTree(6);
+      initialRoot = singleTree.root()
 
       bulkTree.bulkInsert(elements);
 
@@ -109,6 +111,8 @@ describe('Merkle Tree tests', () => {
       }
 
       expect(bulkTree.root().toHexString()).to.eq(singleTree.root().toHexString());
+      // checking if root matches root without any elements as all of them have been removed
+      expect(bulkTree.root().toHexString()).to.eq(initialRoot.toHexString());
     });
   });
 

--- a/packages/sdk-core/src/merkle-tree.ts
+++ b/packages/sdk-core/src/merkle-tree.ts
@@ -100,7 +100,13 @@ export class MerkleTree {
     this.update(this._layers[0].length, BigNumber.from(element));
   }
 
-  removeByElem(element: BigNumberish) {
+  bulkRemove(elements: BigNumberish[]) {
+    for (const elem of elements) {
+      this.remove(elem)
+    }
+  }
+
+  remove(element: BigNumberish) {
     const index = this.indexOf(element)
     if(index == -1) {
       throw new Error('Element is not in the merkle tree');

--- a/packages/sdk-core/src/merkle-tree.ts
+++ b/packages/sdk-core/src/merkle-tree.ts
@@ -100,6 +100,18 @@ export class MerkleTree {
     this.update(this._layers[0].length, BigNumber.from(element));
   }
 
+  removeByElem(element: BigNumberish) {
+    const index = this.indexOf(element)
+    if(index == -1) {
+      throw new Error('Element is not in the merkle tree');
+    }
+    this.removeByIndex(index)
+  }
+
+  removeByIndex(index: number) {
+    this.update(index, this.zeroElement);
+  }
+
   /**
    * Insert multiple elements into the tree.
    * @param elements - Elements to insert

--- a/packages/sdk-core/src/merkle-tree.ts
+++ b/packages/sdk-core/src/merkle-tree.ts
@@ -100,21 +100,23 @@ export class MerkleTree {
     this.update(this._layers[0].length, BigNumber.from(element));
   }
 
-  bulkRemove(elements: BigNumberish[]) {
+  bulkRemove (elements: BigNumberish[]) {
     for (const elem of elements) {
-      this.remove(elem)
+      this.remove(elem);
     }
   }
 
-  remove(element: BigNumberish) {
-    const index = this.indexOf(element)
-    if(index == -1) {
+  remove (element: BigNumberish) {
+    const index = this.indexOf(element);
+
+    if (index === -1) {
       throw new Error('Element is not in the merkle tree');
     }
-    this.removeByIndex(index)
+
+    this.removeByIndex(index);
   }
 
-  removeByIndex(index: number) {
+  removeByIndex (index: number) {
     this.update(index, this.zeroElement);
   }
 


### PR DESCRIPTION
Since we've integrated webb's merkle-tree with `semaphore-anchor/packages/group` I had to comment out the remove function from the package as the merkle-tree class didn't provide a method to remove elements from it.
(https://github.com/webb-tools/semaphore-anchor/blob/develop/packages/group/src/group.ts#L94)

This change adds the three methods `bulkRemove` `remove` and `removeByIndex` to allow uncommenting of the remove method