### PR TITLE
Update proof input parameter of indices to leaf identifier

### DIFF
--- a/packages/sdk-core/src/__test__/arkworks-proving.spec.ts
+++ b/packages/sdk-core/src/__test__/arkworks-proving.spec.ts
@@ -147,8 +147,8 @@ describe('Arkworks Proving manager VAnchor', function () {
       encryptedCommitments: [comEnc1, comEnc2],
       extAmount: '0',
       fee: '0',
-      indices: [0],
       inputUtxos: [vanchorUtxo],
+      leafIds: [{ index: 0, typedChainId: 0 }],
       leavesMap,
       output: [new Utxo((output1)), new Utxo(output2)],
       provingKey: keys.pk,
@@ -211,8 +211,8 @@ describe('Arkworks Proving manager VAnchor', function () {
       encryptedCommitments: [comEnc1, comEnc2],
       extAmount: '0',
       fee: '0',
-      indices: [0, 1],
       inputUtxos: [utxo1, utxo2],
+      leafIds: [{ index: 0, typedChainId: 0 }, { index: 1, typedChainId: 0 }],
       leavesMap,
       output: [new Utxo(output1), new Utxo(output2)],
       provingKey: keys.pk,
@@ -272,8 +272,10 @@ describe('Arkworks Proving manager VAnchor', function () {
       encryptedCommitments: [comEnc1, comEnc2],
       extAmount: '0',
       fee: '0',
-      indices: inputUtxos.map((_, index) => index),
       inputUtxos,
+      leafIds: [...inputUtxos.map((utxo) => {
+        return { index: utxo.index!, typedChainId: Number(utxo.chainId) };
+      })],
       leavesMap,
       output: [new Utxo(output1), new Utxo(output2)],
 
@@ -336,8 +338,10 @@ describe('Arkworks Proving manager VAnchor', function () {
       encryptedCommitments: [comEnc1, comEnc2],
       extAmount: '0',
       fee: '0',
-      indices: utxos.map((_, index) => index),
       inputUtxos: utxos,
+      leafIds: [...utxos.map((utxo) => {
+        return { index: utxo.index!, typedChainId: Number(utxo.chainId) };
+      })],
       leavesMap,
       output: [new Utxo(output1), new Utxo(output2)],
 
@@ -404,8 +408,10 @@ describe('Arkworks Proving manager VAnchor', function () {
         encryptedCommitments: [comEnc1, comEnc2],
         extAmount: '0',
         fee: '0',
-        indices: utxos.map((_, index) => index),
         inputUtxos: utxos,
+        leafIds: [...utxos.map((utxo) => {
+          return { index: utxo.index!, typedChainId: Number(utxo.chainId) };
+        })],
         leavesMap,
         output: [new Utxo(output1), new Utxo(output2)],
         provingKey: keys.pk,
@@ -483,8 +489,8 @@ describe('Arkworks Proving manager VAnchor', function () {
       encryptedCommitments: [comEnc1, comEnc2],
       extAmount: '0',
       fee: '0',
-      indices: [depositedUtxo.index!],
       inputUtxos: [depositedUtxo],
+      leafIds: [{ index: depositedUtxo.index!, typedChainId: Number(depositedUtxo.chainId) }],
       leavesMap,
       output: [new Utxo(output1), new Utxo(output2)],
 
@@ -562,8 +568,10 @@ describe('Arkworks Proving manager VAnchor', function () {
       encryptedCommitments: [comEnc1, comEnc2],
       extAmount: '0',
       fee: '0',
-      indices: utxos.map((utxo) => utxo.index!),
       inputUtxos: utxos,
+      leafIds: [...utxos.map((utxo) => {
+        return { index: utxo.index!, typedChainId: Number(utxo.chainId) };
+      })],
       leavesMap,
       output: [new Utxo(output1), new Utxo(output2)],
 
@@ -644,8 +652,10 @@ describe('Arkworks Proving manager VAnchor', function () {
       encryptedCommitments: [comEnc1, comEnc2],
       extAmount: '0',
       fee: '0',
-      indices: utxos.map((utxo) => utxo.index!),
       inputUtxos: utxos,
+      leafIds: [...utxos.map((utxo) => {
+        return { index: utxo.index!, typedChainId: Number(utxo.chainId) };
+      })],
       leavesMap,
       output: [new Utxo(output1), new Utxo(output2)],
 

--- a/packages/sdk-core/src/proving/circom/proving-manager-thread.ts
+++ b/packages/sdk-core/src/proving/circom/proving-manager-thread.ts
@@ -75,17 +75,16 @@ export class CircomProvingManagerThread {
     if (protocol === 'vanchor') {
       const input = pmSetupInput as WorkerVAnchorPMSetupInput;
       const inputUtxos = await Promise.all(input.inputUtxos.map((utxo) => CircomUtxo.deserialize(utxo)));
-      const indices = [...input.indices];
 
-      if (inputUtxos.length !== indices.length) {
+      if (inputUtxos.length !== input.leafIds.length) {
         throw new Error(
-          `Input notes and indices size don't match notes count (${inputUtxos.length}) indices count (${indices.length})`
+          `Input utxos and leaf identifiers don't match! utxos count (${inputUtxos.length}) ids count (${input.leafIds.length})`
         );
       }
 
       // Set the leaf index on the notes
       for (let i = 0; i < inputUtxos.length; i++) {
-        inputUtxos[i].setIndex(indices[i]);
+        inputUtxos[i].setIndex(input.leafIds[i].index);
       }
 
       // Account for empty leaves set on the merkle tree
@@ -107,7 +106,7 @@ export class CircomProvingManagerThread {
             pathIndices: new Array(this.treeDepth).fill(0)
           });
         } else {
-          mt = new MerkleTree(this.treeDepth, input.leavesMap[(inputUtxos[i].originChainId || inputUtxos[i].chainId)].map((u8a) => u8aToHex(u8a)));
+          mt = new MerkleTree(this.treeDepth, input.leavesMap[input.leafIds[i].typedChainId].map((u8a) => u8aToHex(u8a)));
           merkleProofs.push(mt.path(Number(inputUtxos[i].index)));
         }
       }

--- a/packages/sdk-core/src/proving/types.ts
+++ b/packages/sdk-core/src/proving/types.ts
@@ -20,6 +20,17 @@ export interface ProvingManagerPayload extends Record<NoteProtocol, any> {
 }
 
 /**
+ * Interface to pass as parameter for proving managers.
+ * Corresponds to the respective inputUtxo at the same index.
+ * @param index - Index of the leaf in the tree
+ * @param chainId - The typedChainId index into the leavesMap.
+ */
+export interface LeafIdentifier {
+  index: number,
+  typedChainId: number
+}
+
+/**
  * Proving Manager setup input for the proving manager over sdk-core
  * @param note - Serialized note representation
  * @param relayer - Relayer account id converted to hex string (Without a `0x` prefix)
@@ -45,7 +56,7 @@ export type MixerPMSetupInput = {
  * Proving Manager setup input for anchor API proving manager over sdk-core
  * @param inputNotes - VAnchor notes representing input UTXOs for proving
  * @param leavesMap - Leaves for generating the merkle path, it's indexed by the chain_id and for each entry the values are list of leaves for this chain
- * @param indices -  Leaf indices for input UTXOs leaves
+ * @param leafIds -  Identify a leaf's <index> for leaves at <typedChainId>'s entry in the leavesMap
  * @param roots - Roots set for every anchor
  * @param chainId - The chain id where the input UTXOs being spent
  * @param output - Configuration to shape the output UTXOs
@@ -62,7 +73,7 @@ export type MixerPMSetupInput = {
 export type VAnchorPMSetupInput = {
   inputUtxos: Utxo[];
   leavesMap: Record<string, Leaves>;
-  indices: number[];
+  leafIds: LeafIdentifier[];
   roots: Leaves;
   chainId: string;
   output: [Utxo, Utxo];

--- a/packages/sdk-core/src/proving/worker-utils.ts
+++ b/packages/sdk-core/src/proving/worker-utils.ts
@@ -18,7 +18,7 @@ import type { Backend, Leaves, NoteProtocol } from '@webb-tools/wasm-utils';
 import { Utxo } from '@webb-tools/sdk-core/index.js';
 
 import { CircomUtxo } from '../solidity-utils/index.js';
-import { MixerPMSetupInput, MixerProof, ProofInterface, ProvingManagerSetupInput, VAnchorPMSetupInput } from './types.js';
+import { LeafIdentifier, MixerPMSetupInput, MixerProof, ProofInterface, ProvingManagerSetupInput, VAnchorPMSetupInput } from './types.js';
 
 export type WorkerProvingManagerSetupInput<T extends NoteProtocol> = WorkerProvingManagerPayload[T];
 
@@ -30,7 +30,7 @@ export interface WorkerProvingManagerPayload extends Record<NoteProtocol, any> {
 export type WorkerVAnchorPMSetupInput = {
   inputUtxos: string[];
   leavesMap: Record<string, Leaves>;
-  indices: number[];
+  leafIds: LeafIdentifier[];
   roots: Leaves;
   chainId: string;
   output: [string, string];
@@ -113,8 +113,8 @@ export function workerInputMapper<T extends NoteProtocol> (
         encryptedCommitments: sourceSetupInput.encryptedCommitments,
         extAmount: sourceSetupInput.extAmount,
         fee: sourceSetupInput.fee,
-        indices: sourceSetupInput.indices,
         inputUtxos,
+        leafIds: sourceSetupInput.leafIds,
         leavesMap: sourceSetupInput.leavesMap,
         output: outputUtxos,
         provingKey: sourceSetupInput.provingKey,

--- a/packages/sdk-core/src/solidity-utils/circom-utxo.ts
+++ b/packages/sdk-core/src/solidity-utils/circom-utxo.ts
@@ -55,7 +55,6 @@ export class CircomUtxo extends Utxo {
    *   parts[6] Optional - EncryptionKey, the public key of "publicKey = encryptionScheme(privateKey)" value used for messaging.
    *   parts[7] Optional - PrivateKey, the secret key component correlated to the above values.
    *   parts[8] Optional - Index, the leaf index if the utxo has been inserted in a merkle tree
-   *
    * @returns The CircomUtxo object implementation of a Utxo.
    */
   static async deserialize (utxoString: string): Promise<Utxo> {
@@ -106,6 +105,10 @@ export class CircomUtxo extends Utxo {
 
     if (input.keypair) {
       utxo.setKeypair(input.keypair);
+    } else {
+      // Populate the _pubkey and _secret_key values with
+      // the random default keypair
+      utxo.setKeypair(utxo.keypair);
     }
 
     utxo._blinding = input.blinding ? u8aToHex(input.blinding).slice(2) : toFixedHex(randomBN(31)).slice(2);

--- a/tests/integration_tests/substrate/vanchorTests.spec.ts
+++ b/tests/integration_tests/substrate/vanchorTests.spec.ts
@@ -179,8 +179,13 @@ async function basicDeposit(
 
   const setup: ProvingManagerSetupInput<'vanchor'> = {
     chainId: outputChainId.toString(),
-    indices: [0, 0],
     inputUtxos,
+    leafIds: inputUtxos.map((utxo) => {
+      return {
+        index: utxo.index!,
+        typedChainId: Number(utxo.chainId)
+      } 
+    }),
     leavesMap: leavesMap,
     output: [output1, output2],
     encryptedCommitments: [comEnc1, comEnc2],
@@ -287,8 +292,8 @@ async function basicWithdraw(
 
   const setup: ProvingManagerSetupInput<'vanchor'> = {
     chainId: chainId.toString(),
-    indices: [inputUtxo].map(({ index }) => index!),
     inputUtxos: [inputUtxo],
+    leafIds: [{ index: inputUtxo.index!, typedChainId: Number(inputUtxo.chainId)}],
     leavesMap: leavesMap,
     output: [output1, output2],
     encryptedCommitments: [comEnc1, comEnc2],
@@ -388,8 +393,13 @@ async function createVAnchorWithDeposit(
 
   const setup: ProvingManagerSetupInput<'vanchor'> = {
     chainId: outputChainId.toString(),
-    indices: [0, 0],
     inputUtxos,
+    leafIds: inputUtxos.map((utxo) => {
+      return {
+        index: utxo.index!,
+        typedChainId: Number(utxo.chainId)
+      } 
+    }),
     leavesMap: leavesMap,
     output: [output1, output2],
     encryptedCommitments: [comEnc1, comEnc2],
@@ -540,8 +550,13 @@ describe('VAnchor tests', function() {
 
     const setup: ProvingManagerSetupInput<'vanchor'> = {
       chainId: outputChainId.toString(),
-      indices: [0, 0],
       inputUtxos: utxos,
+      leafIds: utxos.map((utxo) => {
+        return {
+          index: utxo.index!,
+          typedChainId: Number(utxo.chainId)
+        } 
+      }),
       leavesMap: leavesMap,
       output: [output1, output2],
       encryptedCommitments: [comEnc1, comEnc2],
@@ -634,8 +649,13 @@ describe('VAnchor tests', function() {
 
     const setup: ProvingManagerSetupInput<'vanchor'> = {
       chainId: chainId.toString(),
-      indices: [leaf1Index, leaf2Index],
       inputUtxos: utxos,
+      leafIds: utxos.map((utxo) => {
+        return {
+          index: utxo.index!,
+          typedChainId: Number(utxo.chainId)
+        } 
+      }),
       leavesMap: leavesMap,
       output: [output1, output2],
       encryptedCommitments: [comEnc1, comEnc2],
@@ -720,8 +740,13 @@ describe('VAnchor tests', function() {
 
     const setup: ProvingManagerSetupInput<'vanchor'> = {
       chainId: chainId.toString(),
-      indices: utxos.map((utxo) => utxo.index!),
       inputUtxos: utxos,
+      leafIds: utxos.map((utxo) => {
+        return {
+          index: utxo.index!,
+          typedChainId: Number(utxo.chainId)
+        } 
+      }),
       leavesMap: leavesMap,
       output: [output1, output2],
       encryptedCommitments: [comEnc1, comEnc2],


### PR DESCRIPTION
When a proving manager is generating merkle proofs for corresponding input utxo, it needs to know the index of the utxo as well as the appropriate leaves.

The 'originChainid' is an optional parameter, and is not accounted for when serialized. But the proof interface requires this information, so we should update the api for the proof interface.