### PR TITLE
Fix ending import

### DIFF
--- a/packages/sdk-core/src/proposals/ProposalKinds.ts
+++ b/packages/sdk-core/src/proposals/ProposalKinds.ts
@@ -1,8 +1,8 @@
-import { BE } from '@webb-tools/sdk-core/proposals/index.js';
 import { Transaction, utils } from 'ethers';
 
 import { hexToU8a, u8aToHex } from '@polkadot/util';
 
+import { BE } from './index.js';
 import { ProposalHeader } from './ProposalHeader.js';
 import { ResourceId } from './ResourceId.js';
 


### PR DESCRIPTION
## Overview
For some reason, the import with path alias causes an error for `sdk-core` users, switched to a relative path import