### PR TITLE
Export `typed-chain-id` As A Separate Module

### DIFF
--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -143,6 +143,16 @@
       "types": "./build/proposals/ResourceId.d.ts",
       "require": "./build/cjs/proposals/ResourceId.js",
       "default": "./build/cjs/proposals/ResourceId.js"
+    },
+    "./typed-chain-id": {
+      "types": "./build/typed-chain-id.d.ts",
+      "require": "./build/cjs/typed-chain-id.js",
+      "default": "./build/typed-chain-id.js"
+    },
+    "./cjs/typed-chain-id": {
+      "types": "./build/typed-chain-id.d.ts",
+      "require": "./build/cjs/typed-chain-id.js",
+      "default": "./build/cjs/typed-chain-id.js"
     }
   },
   "publishConfig": {


### PR DESCRIPTION
### Changes introduced in this PR

Right now, if we use something in the `typed-chain-id` file, we will import the whole `sdk-core` package. That causes `next.js` to fail because `sdk-core` contains wasm files and some node.js modules (like `fs` and `path`).