### PR TITLE
Bump snarkjs to 0.7.2 (latest version)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ logs
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-*.vscode
 rust/target
 .DS_STORE
 .yarn

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "rust-analyzer.linkedProjects": ["packages/wasm-utils/Cargo.toml"]
+}

--- a/packages/sdk-core/package.json
+++ b/packages/sdk-core/package.json
@@ -174,7 +174,7 @@
     "elliptic": "6.5.4",
     "ethers": "5.7.0",
     "ffjavascript": "^0.2.57",
-    "snarkjs": "^0.6.10"
+    "snarkjs": "^0.7.2"
   },
   "devDependencies": {
     "@types/chai": "^4.3.0",

--- a/packages/wasm-utils/src/note/mod.rs
+++ b/packages/wasm-utils/src/note/mod.rs
@@ -187,11 +187,11 @@ impl fmt::Display for JsNote {
 		// Note URI scheme
 		let scheme = "webb://";
 		// Note URI authority
-		let authority = vec![self.version.to_string(), self.protocol.to_string()].join(":");
+		let authority = [self.version.to_string(), self.protocol.to_string()].join(":");
 		// Note URI chain IDs
-		let chain_ids = vec![self.source_chain_id.to_string(), self.target_chain_id.to_string()].join(":");
+		let chain_ids = [self.source_chain_id.to_string(), self.target_chain_id.to_string()].join(":");
 		// Note URI chain identifying data (smart contracts, tree IDs)
-		let chain_identifying_data = vec![
+		let chain_identifying_data = [
 			self.source_identifying_data.to_string(),
 			self.target_identifying_data.to_string(),
 		]
@@ -254,11 +254,11 @@ impl fmt::Display for JsNote {
 		.collect::<Vec<String>>()
 		.join("&");
 		// Note URI queries are prefixed with `?`
-		let misc = vec!["?".to_string(), misc_values].join("");
+		let misc = ["?".to_string(), misc_values].join("");
 
 		let parts: Vec<String> = vec![authority, chain_ids, chain_identifying_data, secrets.to_string(), misc];
 		// Join the parts with `/` and connect to the scheme as is
-		let note = vec![scheme.to_string(), parts.join("/")].join("");
+		let note = [scheme.to_string(), parts.join("/")].join("");
 		write!(f, "{}", note)
 	}
 }

--- a/packages/wasm-utils/src/utxo.rs
+++ b/packages/wasm-utils/src/utxo.rs
@@ -354,15 +354,12 @@ impl fmt::Display for JsUtxo {
 		let backend = Backend::Arkworks.to_string();
 		let amount = self.get_amount_raw().to_string();
 		let chain_id = self.get_chain_id_raw().to_string();
-		let index = self
-			.get_index()
-			.map(|v| v.to_string())
-			.unwrap_or_else(|| "".to_string());
+		let index = self.get_index().map(|v| v.to_string()).unwrap_or_default();
 		let blinding = hex::encode(self.get_blinding());
 		let public_key = hex::encode(self.get_public_key());
 		let private_key = hex::encode(self.get_secret_key().unwrap_or_default());
 
-		let sec = vec![
+		let sec = [
 			curve,
 			backend,
 			amount,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4510,12 +4510,12 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-circom_runtime@0.1.22:
-  version "0.1.22"
-  resolved "https://registry.yarnpkg.com/circom_runtime/-/circom_runtime-0.1.22.tgz#f957c47662cdd03cd3fb76979c434c719a366373"
-  integrity sha512-V/XYZWBhbZY8SotkaGH4FbiDYAZ8a1Md++MBiKPDOuWS/NIJB+Q+XIiTC8zKMgoDaa9cd2OiTvsC9J6te7twNg==
+circom_runtime@0.1.24:
+  version "0.1.24"
+  resolved "https://registry.yarnpkg.com/circom_runtime/-/circom_runtime-0.1.24.tgz#60ca8a31c3675802fbab5a0bcdeb02556e510733"
+  integrity sha512-H7/7I2J/cBmRnZm9docOCGhfxzS61BEm4TMCWcrZGsWNBQhePNfQq88Oj2XpUfzmBTCd8pRvRb3Mvazt3TMrJw==
   dependencies:
-    ffjavascript "0.2.57"
+    ffjavascript "0.2.60"
 
 circomlibjs@^0.0.8:
   version "0.0.8"
@@ -6443,7 +6443,25 @@ fetch-blob@^3.1.2, fetch-blob@^3.1.4:
     node-domexception "^1.0.0"
     web-streams-polyfill "^3.0.3"
 
-ffjavascript@0.2.57, ffjavascript@^0.2.38, ffjavascript@^0.2.48, ffjavascript@^0.2.57:
+ffjavascript@0.2.60:
+  version "0.2.60"
+  resolved "https://registry.yarnpkg.com/ffjavascript/-/ffjavascript-0.2.60.tgz#4d8ae613d6bf4e98b3cc29ba10c626f5853854cf"
+  integrity sha512-T/9bnEL5xAZRDbQoEMf+pM9nrhK+C3JyZNmqiWub26EQorW7Jt+jR54gpqDhceA4Nj0YctPQwYnl8xa52/A26A==
+  dependencies:
+    wasmbuilder "0.0.16"
+    wasmcurves "0.2.2"
+    web-worker "^1.2.0"
+
+ffjavascript@0.2.62:
+  version "0.2.62"
+  resolved "https://registry.yarnpkg.com/ffjavascript/-/ffjavascript-0.2.62.tgz#f508dfe662a70181598ec5eb8ce5127eb342f624"
+  integrity sha512-uJ7MTrdzhX/3f+hxn0XhdXbJCqYZJSBB6y2/ui4t21vKYVjyTMlU80pPXu40ir6qpqbrdzUeKdlOdJ0aFG9UNA==
+  dependencies:
+    wasmbuilder "0.0.16"
+    wasmcurves "0.2.2"
+    web-worker "^1.2.0"
+
+ffjavascript@^0.2.38, ffjavascript@^0.2.48, ffjavascript@^0.2.57:
   version "0.2.57"
   resolved "https://registry.yarnpkg.com/ffjavascript/-/ffjavascript-0.2.57.tgz#ba1be96015b2688192e49f2f4de2cc5150fd8594"
   integrity sha512-V+vxZ/zPNcthrWmqfe/1YGgqdkTamJeXiED0tsk7B84g40DKlrTdx47IqZuiygqAVG6zMw4qYuvXftIJWsmfKQ==
@@ -10531,15 +10549,15 @@ quote-unquote@^1.0.0:
   resolved "https://registry.yarnpkg.com/quote-unquote/-/quote-unquote-1.0.0.tgz#67a9a77148effeaf81a4d428404a710baaac8a0b"
   integrity sha512-twwRO/ilhlG/FIgYeKGFqyHhoEhqgnKVkcmqMKi2r524gz3ZbDTcyFt38E9xjJI2vT+KbRNHVbnJ/e0I25Azwg==
 
-r1csfile@0.0.45:
-  version "0.0.45"
-  resolved "https://registry.yarnpkg.com/r1csfile/-/r1csfile-0.0.45.tgz#59d59a33f8b5280017fc00ee691d003a3d705fe0"
-  integrity sha512-YKIp4D441aZ6OoI9y+bfAyb2j4Cl+OFq/iiX6pPWDrL4ZO968h0dq0w07i65edvrTt7/G43mTnl0qEuLXyp/Yw==
+r1csfile@0.0.47:
+  version "0.0.47"
+  resolved "https://registry.yarnpkg.com/r1csfile/-/r1csfile-0.0.47.tgz#ed95a0dc8e910e9c070253906f7a31bd8c5333c8"
+  integrity sha512-oI4mAwuh1WwuFg95eJDNDDL8hCaZkwnPuNZrQdLBWvDoRU7EG+L/MOHL7SwPW2Y+ZuYcTLpj3rBkgllBQZN/JA==
   dependencies:
     "@iden3/bigarray" "0.0.2"
     "@iden3/binfileutils" "0.0.11"
     fastfile "0.0.20"
-    ffjavascript "0.2.57"
+    ffjavascript "0.2.60"
 
 randombytes@^2.1.0:
   version "2.1.0"
@@ -11423,21 +11441,21 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-snarkjs@^0.6.10:
-  version "0.6.10"
-  resolved "https://registry.yarnpkg.com/snarkjs/-/snarkjs-0.6.10.tgz#d751645a45d2390abcb007c409b31d813bedd108"
-  integrity sha512-Ls9XPTIuW2Ivk2sACM0Pn/FnKZP8UYYqRbzDl3SnglY5Gw28BIp1sfArOxdJJ2QrlbK7e6FFjMHQPvTp0Ttn0w==
+snarkjs@^0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/snarkjs/-/snarkjs-0.7.2.tgz#ab719b065fcd9867d9ea14bed92f3acdca3c766f"
+  integrity sha512-A8yPFm9pRnZ7XYXfPSjSFnugEV1rsHGjb8W7c0Qk7nzXl5h3WANTkpVC5FYxakmw/GKWekz7wjjHaOFtPp823Q==
   dependencies:
     "@iden3/binfileutils" "0.0.11"
     bfj "^7.0.2"
     blake2b-wasm "^2.4.0"
-    circom_runtime "0.1.22"
+    circom_runtime "0.1.24"
     ejs "^3.1.6"
     fastfile "0.0.20"
-    ffjavascript "0.2.57"
+    ffjavascript "0.2.62"
     js-sha3 "^0.8.0"
     logplease "^1.2.15"
-    r1csfile "0.0.45"
+    r1csfile "0.0.47"
 
 sockjs-client@^1.5.0:
   version "1.6.1"
@@ -12552,6 +12570,13 @@ wasmcurves@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/wasmcurves/-/wasmcurves-0.2.0.tgz#ccfc5a7d3778b6e0768b82a9336c80054f9bc0cf"
   integrity sha512-3e2rbxdujOwaod657gxgmdhZNn+i1qKdHO3Y/bK+8E7bV8ttV/fu5FO4/WLBACF375cK0QDLOP+65Na63qYuWA==
+  dependencies:
+    wasmbuilder "0.0.16"
+
+wasmcurves@0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/wasmcurves/-/wasmcurves-0.2.2.tgz#ca444f6a6f6e2a5cbe6629d98ff478a62b4ccb2b"
+  integrity sha512-JRY908NkmKjFl4ytnTu5ED6AwPD+8VJ9oc94kdq7h5bIwbj0L4TDJ69mG+2aLs2SoCmGfqIesMWTEJjtYsoQXQ==
   dependencies:
     wasmbuilder "0.0.16"
 


### PR DESCRIPTION
### Summary of changes

- We need to address the build issue related to the default export of the `fastfile` module in Next.js applications. This problem will be resolved in the latest version of snarkjs.

![CleanShot 2023-11-02 at 20 58 18@2x](https://github.com/webb-tools/webb.js/assets/60747384/d57958a1-7244-4b16-9db7-fe276134b1d4)
